### PR TITLE
QuestUseCase 작성 및 테스트

### DIFF
--- a/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
+++ b/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		34ACC364291DEF6100741371 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 34ACC363291DEF6100741371 /* FirebaseFirestore */; };
 		34ACC366291DEF6100741371 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 34ACC365291DEF6100741371 /* FirebaseStorage */; };
 		34ACC36C291DF0DD00741371 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 34ACC36B291DF0DD00741371 /* GoogleService-Info.plist */; };
+		34CAE318292B19A3007653AD /* QuestsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CAE317292B19A3007653AD /* QuestsRepository.swift */; };
 		34EE6EB72924C674005AF583 /* QuestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EE6EB62924C674005AF583 /* QuestView.swift */; };
 		34EE6EB92924CAA1005AF583 /* QuestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EE6EB82924CAA1005AF583 /* QuestViewModel.swift */; };
 		A51189C329226E66008A9D33 /* UserQuestEntity+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51189C229226E66008A9D33 /* UserQuestEntity+Mapping.swift */; };
@@ -125,6 +126,7 @@
 		34ACC34D291DE9C100741371 /* DailyQuestUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyQuestUITests.swift; sourceTree = "<group>"; };
 		34ACC34F291DE9C100741371 /* DailyQuestUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyQuestUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		34ACC36B291DF0DD00741371 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		34CAE317292B19A3007653AD /* QuestsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestsRepository.swift; sourceTree = "<group>"; };
 		34EE6EB62924C674005AF583 /* QuestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestView.swift; sourceTree = "<group>"; };
 		34EE6EB82924CAA1005AF583 /* QuestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestViewModel.swift; sourceTree = "<group>"; };
 		A51189C229226E66008A9D33 /* UserQuestEntity+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserQuestEntity+Mapping.swift"; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 		3499551829232A05007AB99E /* Repositories */ = {
 			isa = PBXGroup;
 			children = (
+				34CAE317292B19A3007653AD /* QuestsRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -734,6 +737,7 @@
 				34A529E7292481E1001BAD34 /* BrowseCoordinator.swift in Sources */,
 				34A529D329247903001BAD34 /* TabCoordinator.swift in Sources */,
 				34EE6EB92924CAA1005AF583 /* QuestViewModel.swift in Sources */,
+				34CAE318292B19A3007653AD /* QuestsRepository.swift in Sources */,
 				3449AD5D2922197000B87619 /* User.swift in Sources */,
 				A51F01CD29233ABB0031ECA2 /* RealmUserInfoStorage.swift in Sources */,
 				A51F01DA292345990031ECA2 /* BrowseQuest.swift in Sources */,

--- a/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
+++ b/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
@@ -7,9 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		340FDFD3292B5CE300C4E3DC /* QuestsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CAE317292B19A3007653AD /* QuestsRepository.swift */; };
+		340FDFD4292B5DA100C4E3DC /* QuestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3416FC87292B54DB00B504C5 /* QuestUseCase.swift */; };
+		340FDFD5292B5DB700C4E3DC /* DefaultQuestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3416FC89292B560800B504C5 /* DefaultQuestUseCase.swift */; };
 		34131397291E47D300E607E1 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 34131396291E47D300E607E1 /* RxCocoa */; };
 		34131399291E47D300E607E1 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 34131398291E47D300E607E1 /* RxSwift */; };
 		3413139C291E480500E607E1 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3413139B291E480500E607E1 /* SnapKit */; };
+		3416FC88292B54DB00B504C5 /* QuestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3416FC87292B54DB00B504C5 /* QuestUseCase.swift */; };
+		3416FC8A292B560800B504C5 /* DefaultQuestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3416FC89292B560800B504C5 /* DefaultQuestUseCase.swift */; };
+		3416FC8E292B593C00B504C5 /* Quest+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3416FC8D292B593C00B504C5 /* Quest+Stub.swift */; };
+		3416FC93292B59D300B504C5 /* QuestRepositoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3416FC92292B59D300B504C5 /* QuestRepositoryMock.swift */; };
+		3416FC95292B5AD600B504C5 /* QuestUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3416FC94292B5AD600B504C5 /* QuestUseCaseTests.swift */; };
+		3416FC96292B5B5400B504C5 /* Quest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3449AD5A2922164B00B87619 /* Quest.swift */; };
 		3449AD5B2922164B00B87619 /* Quest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3449AD5A2922164B00B87619 /* Quest.swift */; };
 		3449AD5D2922197000B87619 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3449AD5C2922197000B87619 /* User.swift */; };
 		3449AD6029222B3900B87619 /* UserInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3449AD5F29222B3900B87619 /* UserInfoCell.swift */; };
@@ -40,7 +49,6 @@
 		34ACC32F291DE9C000741371 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34ACC32E291DE9C000741371 /* SceneDelegate.swift */; };
 		34ACC336291DE9C100741371 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 34ACC335291DE9C100741371 /* Assets.xcassets */; };
 		34ACC339291DE9C100741371 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 34ACC337291DE9C100741371 /* LaunchScreen.storyboard */; };
-		34ACC344291DE9C100741371 /* DailyQuestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34ACC343291DE9C100741371 /* DailyQuestTests.swift */; };
 		34ACC34E291DE9C100741371 /* DailyQuestUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34ACC34D291DE9C100741371 /* DailyQuestUITests.swift */; };
 		34ACC350291DE9C100741371 /* DailyQuestUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34ACC34F291DE9C100741371 /* DailyQuestUITestsLaunchTests.swift */; };
 		34ACC360291DEF6100741371 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 34ACC35F291DEF6100741371 /* FirebaseAuth */; };
@@ -88,6 +96,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3416FC87292B54DB00B504C5 /* QuestUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestUseCase.swift; sourceTree = "<group>"; };
+		3416FC89292B560800B504C5 /* DefaultQuestUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultQuestUseCase.swift; sourceTree = "<group>"; };
+		3416FC8D292B593C00B504C5 /* Quest+Stub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Quest+Stub.swift"; sourceTree = "<group>"; };
+		3416FC92292B59D300B504C5 /* QuestRepositoryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestRepositoryMock.swift; sourceTree = "<group>"; };
+		3416FC94292B5AD600B504C5 /* QuestUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestUseCaseTests.swift; sourceTree = "<group>"; };
 		3449AD5A2922164B00B87619 /* Quest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quest.swift; sourceTree = "<group>"; };
 		3449AD5C2922197000B87619 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		3449AD5F29222B3900B87619 /* UserInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoCell.swift; sourceTree = "<group>"; };
@@ -121,7 +134,6 @@
 		34ACC338291DE9C100741371 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		34ACC33A291DE9C100741371 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		34ACC33F291DE9C100741371 /* DailyQuestTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DailyQuestTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		34ACC343291DE9C100741371 /* DailyQuestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyQuestTests.swift; sourceTree = "<group>"; };
 		34ACC349291DE9C100741371 /* DailyQuestUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DailyQuestUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		34ACC34D291DE9C100741371 /* DailyQuestUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyQuestUITests.swift; sourceTree = "<group>"; };
 		34ACC34F291DE9C100741371 /* DailyQuestUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyQuestUITestsLaunchTests.swift; sourceTree = "<group>"; };
@@ -180,6 +192,63 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		340FDFD8292B61C200C4E3DC /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		3416FC85292B549900B504C5 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				3416FC86292B54BF00B504C5 /* Protocols */,
+				3416FC89292B560800B504C5 /* DefaultQuestUseCase.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		3416FC86292B54BF00B504C5 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				3416FC87292B54DB00B504C5 /* QuestUseCase.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
+		3416FC8B292B58F600B504C5 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				3416FC90292B59BB00B504C5 /* UseCases */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		3416FC8C292B592C00B504C5 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				3416FC8D292B593C00B504C5 /* Quest+Stub.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		3416FC90292B59BB00B504C5 /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				3416FC94292B5AD600B504C5 /* QuestUseCaseTests.swift */,
+				3416FC91292B59C700B504C5 /* Mocks */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		3416FC91292B59C700B504C5 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				3416FC92292B59D300B504C5 /* QuestRepositoryMock.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		3449AD592922162E00B87619 /* Entities */ = {
 			isa = PBXGroup;
 			children = (
@@ -233,6 +302,7 @@
 		34995516292329F4007AB99E /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
+				3416FC85292B549900B504C5 /* Home */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -390,7 +460,9 @@
 		34ACC342291DE9C100741371 /* DailyQuestTests */ = {
 			isa = PBXGroup;
 			children = (
-				34ACC343291DE9C100741371 /* DailyQuestTests.swift */,
+				340FDFD8292B61C200C4E3DC /* Presentation */,
+				3416FC8B292B58F600B504C5 /* Domain */,
+				3416FC8C292B592C00B504C5 /* Mocks */,
 			);
 			path = DailyQuestTests;
 			sourceTree = "<group>";
@@ -743,6 +815,7 @@
 				A51F01DA292345990031ECA2 /* BrowseQuest.swift in Sources */,
 				A5AC96E629223F06003B7637 /* UserQuestsStorage.swift in Sources */,
 				A51F01D52923407E0031ECA2 /* BrowseQuestEntity.swift in Sources */,
+				3416FC8A292B560800B504C5 /* DefaultQuestUseCase.swift in Sources */,
 				A51F01C82923392F0031ECA2 /* UserInfoStorage.swift in Sources */,
 				34A529E429248178001BAD34 /* SettingsSceneDIContainer.swift in Sources */,
 				34A529E029247F1F001BAD34 /* HomeViewController.swift in Sources */,
@@ -765,6 +838,7 @@
 				A51F01D8292343A80031ECA2 /* RealmBrowseQuestsStorage.swift in Sources */,
 				A51F01DD2923468F0031ECA2 /* BrowseQuestEntity+Mapping.swift in Sources */,
 				A5AC96DC292237C3003B7637 /* UserQuestEntity.swift in Sources */,
+				3416FC88292B54DB00B504C5 /* QuestUseCase.swift in Sources */,
 				A51F01D029233C510031ECA2 /* UserInfoEntity+Mapping.swift in Sources */,
 				3499552B29236041007AB99E /* BrowseViewModel.swift in Sources */,
 				3449AD5B2922164B00B87619 /* Quest.swift in Sources */,
@@ -780,7 +854,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				34ACC344291DE9C100741371 /* DailyQuestTests.swift in Sources */,
+				3416FC96292B5B5400B504C5 /* Quest.swift in Sources */,
+				3416FC95292B5AD600B504C5 /* QuestUseCaseTests.swift in Sources */,
+				3416FC8E292B593C00B504C5 /* Quest+Stub.swift in Sources */,
+				340FDFD5292B5DB700C4E3DC /* DefaultQuestUseCase.swift in Sources */,
+				3416FC93292B59D300B504C5 /* QuestRepositoryMock.swift in Sources */,
+				340FDFD4292B5DA100C4E3DC /* QuestUseCase.swift in Sources */,
+				340FDFD3292B5CE300C4E3DC /* QuestsRepository.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DailyQuest/DailyQuest/Data/PersistentStorages/UserQuestsStorage/RealmStorage/EntityMapping/UserQuestEntity+Mapping.swift
+++ b/DailyQuest/DailyQuest/Data/PersistentStorages/UserQuestsStorage/RealmStorage/EntityMapping/UserQuestEntity+Mapping.swift
@@ -11,8 +11,8 @@ extension UserQuestEntity {
     convenience init(quest: Quest) {
         self.init(uuid: quest.uuid,
                   title: quest.title,
-                  startDay: quest.startDay,
-                  endDay: quest.endDay,
+                  startDay: Date(), // no more use
+                  endDay: Date(), // no more use
                   currentCount: quest.currentCount,
                   totalCount: quest.totalCount)
     }
@@ -20,11 +20,9 @@ extension UserQuestEntity {
 
 extension UserQuestEntity {
     func toDomain() -> Quest {
-        return Quest(uuid: uuid,
+        return Quest(groupId: UUID(), // update here
+                     uuid: uuid,
                      title: title,
-                     startDay: startDay,
-                     endDay: endDay,
-                     repeat: `repeat`,
                      currentCount: currentCount,
                      totalCount: totalCount)
     }

--- a/DailyQuest/DailyQuest/Domain/Entities/Quest.swift
+++ b/DailyQuest/DailyQuest/Domain/Entities/Quest.swift
@@ -8,11 +8,9 @@
 import Foundation
 
 struct Quest {
+    let groupId: UUID
     let uuid: UUID
     let title: String
-    let startDay: Date
-    let endDay: Date
-    let `repeat`: Int
     var currentCount: Int
     let totalCount: Int
     

--- a/DailyQuest/DailyQuest/Domain/Interfaces/Repositories/QuestsRepository.swift
+++ b/DailyQuest/DailyQuest/Domain/Interfaces/Repositories/QuestsRepository.swift
@@ -1,0 +1,58 @@
+//
+//  QuestsRepository.swift
+//  DailyQuest
+//
+//  Created by jinwoong Kim on 2022/11/21.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol QuestsRepository {
+    /**
+     해당 퀘스트를 저장합니다.
+     
+     - Parameters:
+        - quest: 저장할 퀘스트입니다.
+     - Returns: 성공시 Quest를, 실패시, error를 방출하는 Observable입니다.
+     */
+    func save(with quest: [Quest]) -> Single<[Quest]>
+    
+    /**
+     해당 날짜의 퀘스트 배열을 받아옵니다.
+     
+     - Parameters:
+        - date: 받아오길 원하는 날짜입니다.
+     - Returns: Quest의 배열을 방출하는 Observable입니다. 비어있다면 비어있는 배열을 방출합니다.
+     */
+    func fetch(by date: Date) -> Observable<[Quest]>
+    
+    /**
+     해당 날짜의 퀘스트 값(`currentCount`)을 업데이트 합니다.
+     
+     - Parameters:
+        - quest: 업데이트될 퀘스트입니다.
+     - Returns: 성공시 Quest를, 실패시 error를 방출하는 Observable입니다.
+     */
+    func update(with quest: Quest) -> Single<Quest>
+    
+    /**
+     해당 날짜에 해당하는 퀘스트의 값을 업데이트 합니다.
+     
+     - Parameters:
+        - questId: 삭제하고자 하는 퀘스트의 id입니다.
+     - Returns: 성공시 해당 Quest를, 실패시 error를 방출하는 Observable입니다.
+     */
+    func delete(with questId: UUID) -> Single<Quest>
+    
+    /**
+     해당 group의 Quest를 모두 삭제합니다.
+     
+     
+     - Parameters:
+        - groupId: 삭제하고자 하는 퀘스트 그룹의 id입니다.
+     - Returns: 성공시 해당 Quest 배열을, 실패시 error를 방출하는 Observable입니다.
+     */
+    func deleteAll(with groupId: UUID) -> Single<[Quest]>
+}

--- a/DailyQuest/DailyQuest/Domain/UseCases/Home/DefaultQuestUseCase.swift
+++ b/DailyQuest/DailyQuest/Domain/UseCases/Home/DefaultQuestUseCase.swift
@@ -1,0 +1,8 @@
+//
+//  DefaultQuestUseCase.swift
+//  DailyQuest
+//
+//  Created by jinwoong Kim on 2022/11/21.
+//
+
+import Foundation

--- a/DailyQuest/DailyQuest/Domain/UseCases/Home/DefaultQuestUseCase.swift
+++ b/DailyQuest/DailyQuest/Domain/UseCases/Home/DefaultQuestUseCase.swift
@@ -6,3 +6,19 @@
 //
 
 import Foundation
+
+import RxSwift
+
+final class DefaultQuestUseCase {
+    private let questsRepository: QuestsRepository
+    
+    init(questsRepository: QuestsRepository) {
+        self.questsRepository = questsRepository
+    }
+}
+
+extension DefaultQuestUseCase: QuestUseCase {
+    func fetch(by date: Date) -> Observable<[Quest]> {
+        return questsRepository.fetch(by: date)
+    }
+}

--- a/DailyQuest/DailyQuest/Domain/UseCases/Home/Protocols/QuestUseCase.swift
+++ b/DailyQuest/DailyQuest/Domain/UseCases/Home/Protocols/QuestUseCase.swift
@@ -1,0 +1,14 @@
+//
+//  QuestUseCase.swift
+//  DailyQuest
+//
+//  Created by jinwoong Kim on 2022/11/21.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol QuestUseCase {
+    func fetch(by date: Date) -> Observable<[Quest]>
+}

--- a/DailyQuest/DailyQuest/Presentation/Browse/ViewModel/BrowseViewModel.swift
+++ b/DailyQuest/DailyQuest/Presentation/Browse/ViewModel/BrowseViewModel.swift
@@ -12,26 +12,26 @@ import RxSwift
 final class BrowseViewModel {
     let user1 = User(uuid: "", nickName: "jinwoong", profile: Data(), backgroundImage: Data(), description: "")
     let quests1 = [
-        Quest(uuid: UUID(), title: "물마시기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 2, totalCount: 5),
-        Quest(uuid: UUID(), title: "코딩하기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 0, totalCount: 10)
+        Quest(groupId: UUID(), uuid: UUID(), title: "물마시기", currentCount: 2, totalCount: 5),
+        Quest(groupId: UUID(),uuid: UUID(), title: "코딩하기", currentCount: 0, totalCount: 10)
     ]
     
     let user2 = User(uuid: "", nickName: "someone", profile: Data(), backgroundImage: Data(), description: "")
     let quests2 = [
-        Quest(uuid: UUID(), title: "물마시기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 4, totalCount: 5),
-        Quest(uuid: UUID(), title: "책읽기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 9, totalCount: 20),
-        Quest(uuid: UUID(), title: "달리기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 4, totalCount: 9),
-        Quest(uuid: UUID(), title: "잠자기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 1, totalCount: 1)
+        Quest(groupId: UUID(),uuid: UUID(), title: "물마시기", currentCount: 4, totalCount: 5),
+        Quest(groupId: UUID(),uuid: UUID(), title: "책읽기", currentCount: 9, totalCount: 20),
+        Quest(groupId: UUID(),uuid: UUID(), title: "달리기", currentCount: 4, totalCount: 9),
+        Quest(groupId: UUID(),uuid: UUID(), title: "잠자기", currentCount: 1, totalCount: 1)
     ]
     
     let user3 = User(uuid: "", nickName: "Max...", profile: Data(), backgroundImage: Data(), description: "")
     let quests3 = [
-        Quest(uuid: UUID(), title: "물마시기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 4, totalCount: 5),
-        Quest(uuid: UUID(), title: "그림 그리기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 1, totalCount: 2),
-        Quest(uuid: UUID(), title: "달리기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 4, totalCount: 9),
-        Quest(uuid: UUID(), title: "책읽기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 1, totalCount: 1),
-        Quest(uuid: UUID(), title: "잠자기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 1, totalCount: 1),
-        Quest(uuid: UUID(), title: "행복하기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 0, totalCount: 1)
+        Quest(groupId: UUID(),uuid: UUID(), title: "물마시기", currentCount: 4, totalCount: 5),
+        Quest(groupId: UUID(),uuid: UUID(), title: "그림 그리기", currentCount: 1, totalCount: 2),
+        Quest(groupId: UUID(),uuid: UUID(), title: "달리기", currentCount: 4, totalCount: 9),
+        Quest(groupId: UUID(),uuid: UUID(), title: "책읽기", currentCount: 1, totalCount: 1),
+        Quest(groupId: UUID(),uuid: UUID(), title: "잠자기", currentCount: 1, totalCount: 1),
+        Quest(groupId: UUID(),uuid: UUID(), title: "행복하기", currentCount: 0, totalCount: 1)
     ]
     
     let data: Observable<[(User, [Quest])]>

--- a/DailyQuest/DailyQuest/Presentation/Common/Cells/QuestCell.swift
+++ b/DailyQuest/DailyQuest/Presentation/Common/Cells/QuestCell.swift
@@ -111,7 +111,7 @@ struct QuestCellPreview: PreviewProvider{
     static var previews: some View {
         UIViewPreview {
             let cell = QuestCell(frame: .zero)
-            let quest = Quest(uuid: UUID(), title: "my quest", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 2, totalCount: 5)
+            let quest = Quest(groupId: UUID(), uuid: UUID(), title: "my quest", currentCount: 2, totalCount: 5)
             
             cell.setup(with: quest)
             return cell

--- a/DailyQuest/DailyQuest/Presentation/Home/View/QuestView.swift
+++ b/DailyQuest/DailyQuest/Presentation/Home/View/QuestView.swift
@@ -33,13 +33,13 @@ final class QuestView: UITableView {
     }
     
     private func bind() {
-        viewModel
-            .data
-            .bind(to: rx.items(cellIdentifier: QuestCell.reuseIdentifier, cellType: QuestCell.self)) { row, item, cell in
-                cell.setup(with: item)
-                cell.backgroundColor = .white
-            }
-            .disposed(by: disposableBag)
+//        viewModel
+//            .data
+//            .bind(to: rx.items(cellIdentifier: QuestCell.reuseIdentifier, cellType: QuestCell.self)) { row, item, cell in
+//                cell.setup(with: item)
+//                cell.backgroundColor = .white
+//            }
+//            .disposed(by: disposableBag)
     }
 }
 

--- a/DailyQuest/DailyQuest/Presentation/Home/ViewController/HomeViewController.swift
+++ b/DailyQuest/DailyQuest/Presentation/Home/ViewController/HomeViewController.swift
@@ -23,7 +23,7 @@ final class HomeViewController: UIViewController {
     
     private lazy var questView: QuestView = {
         let questView = QuestView()
-        questView.setup(with: QuestViewModel())
+//        questView.setup(with: QuestViewModel())
         
         return questView
     }()

--- a/DailyQuest/DailyQuest/Presentation/Home/ViewModel/QuestViewModel.swift
+++ b/DailyQuest/DailyQuest/Presentation/Home/ViewModel/QuestViewModel.swift
@@ -10,16 +10,16 @@ import Foundation
 import RxSwift
 
 final class QuestViewModel {
-    let quests = [
-        Quest(groupId: UUID(), uuid: UUID(), title: "물마시기", currentCount: 4, totalCount: 5),
-        Quest(groupId: UUID(), uuid: UUID(), title: "책읽기", currentCount: 9, totalCount: 20),
-        Quest(groupId: UUID(), uuid: UUID(), title: "달리기", currentCount: 4, totalCount: 9),
-        Quest(groupId: UUID(), uuid: UUID(), title: "잠자기", currentCount: 1, totalCount: 1)
-    ]
+    private let questUseCase: QuestUseCase
     
-    let data: Observable<[Quest]>
+//    let quests = [
+//        Quest(groupId: UUID(), uuid: UUID(), title: "물마시기", currentCount: 4, totalCount: 5),
+//        Quest(groupId: UUID(), uuid: UUID(), title: "책읽기", currentCount: 9, totalCount: 20),
+//        Quest(groupId: UUID(), uuid: UUID(), title: "달리기", currentCount: 4, totalCount: 9),
+//        Quest(groupId: UUID(), uuid: UUID(), title: "잠자기", currentCount: 1, totalCount: 1)
+//    ]
     
-    init() {
-        self.data = .just(quests)
+    init(questUseCase: QuestUseCase) {
+        self.questUseCase = questUseCase
     }
 }

--- a/DailyQuest/DailyQuest/Presentation/Home/ViewModel/QuestViewModel.swift
+++ b/DailyQuest/DailyQuest/Presentation/Home/ViewModel/QuestViewModel.swift
@@ -11,10 +11,10 @@ import RxSwift
 
 final class QuestViewModel {
     let quests = [
-        Quest(uuid: UUID(), title: "물마시기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 4, totalCount: 5),
-        Quest(uuid: UUID(), title: "책읽기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 9, totalCount: 20),
-        Quest(uuid: UUID(), title: "달리기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 4, totalCount: 9),
-        Quest(uuid: UUID(), title: "잠자기", startDay: Date(), endDay: Date(), repeat: 1, currentCount: 1, totalCount: 1)
+        Quest(groupId: UUID(), uuid: UUID(), title: "물마시기", currentCount: 4, totalCount: 5),
+        Quest(groupId: UUID(), uuid: UUID(), title: "책읽기", currentCount: 9, totalCount: 20),
+        Quest(groupId: UUID(), uuid: UUID(), title: "달리기", currentCount: 4, totalCount: 9),
+        Quest(groupId: UUID(), uuid: UUID(), title: "잠자기", currentCount: 1, totalCount: 1)
     ]
     
     let data: Observable<[Quest]>

--- a/DailyQuest/DailyQuestTests/Domain/UseCases/Mocks/QuestRepositoryMock.swift
+++ b/DailyQuest/DailyQuestTests/Domain/UseCases/Mocks/QuestRepositoryMock.swift
@@ -1,0 +1,8 @@
+//
+//  QuestRepositoryMock.swift
+//  DailyQuestTests
+//
+//  Created by jinwoong Kim on 2022/11/21.
+//
+
+import Foundation

--- a/DailyQuest/DailyQuestTests/Domain/UseCases/Mocks/QuestRepositoryMock.swift
+++ b/DailyQuest/DailyQuestTests/Domain/UseCases/Mocks/QuestRepositoryMock.swift
@@ -6,3 +6,41 @@
 //
 
 import Foundation
+
+import RxSwift
+
+final class QuestRepositoryMock: QuestsRepository {
+    let quests = [
+        Quest.stub(groupId: UUID(),
+                   uuid: UUID(),
+                   title: "물마시기",
+                   currentCount: 0,
+                   totalCount: 10),
+        Quest.stub(groupId: UUID(),
+                   uuid: UUID(),
+                   title: "물마시기",
+                   currentCount: 0,
+                   totalCount: 10),
+    ]
+    
+    func save(with quest: [Quest]) -> Single<[Quest]> {
+        
+        return Single.just([])
+    }
+
+    func update(with quest: Quest) -> Single<Quest> {
+        return Single.just(quests[0])
+    }
+    
+    func delete(with questId: UUID) -> Single<Quest> {
+        return Single.just(quests[0])
+    }
+    
+    func deleteAll(with groupId: UUID) -> Single<[Quest]> {
+        return Single.just(quests)
+    }
+    
+    func fetch(by date: Date) -> Observable<[Quest]> {
+        return Observable.just(quests)
+    }
+}

--- a/DailyQuest/DailyQuestTests/Domain/UseCases/QuestUseCaseTests.swift
+++ b/DailyQuest/DailyQuestTests/Domain/UseCases/QuestUseCaseTests.swift
@@ -7,22 +7,45 @@
 
 import XCTest
 
+import RxSwift
+
 final class QuestUseCaseTests: XCTestCase {
+    private var questUseCase: QuestUseCase!
+    private var questRepo: QuestsRepository!
+    private var disposeBag = DisposeBag()
 
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
+        
     }
 
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
+        questRepo = nil
+        questUseCase = nil
+        disposeBag = .init()
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    func testQuestUseCase_WhenRepoSendCorrectQuests_ThenExpectationWillBeFulfilledWithSuccess() {
+        // given
+        questRepo = QuestRepositoryMock()
+        
+        questUseCase = DefaultQuestUseCase(questsRepository: questRepo)
+        
+        let expectation = XCTestExpectation(description: "test success")
+        
+        // when
+        questUseCase
+            .fetch(by: Date())
+        // then
+            .subscribe(onNext: { data in
+                expectation.fulfill()
+            }, onError: { _ in
+                XCTFail("test failed")
+            })
+            .disposed(by: disposeBag)
+        
+        wait(for: [expectation], timeout: 1)
     }
 
     func testPerformanceExample() throws {

--- a/DailyQuest/DailyQuestTests/Domain/UseCases/QuestUseCaseTests.swift
+++ b/DailyQuest/DailyQuestTests/Domain/UseCases/QuestUseCaseTests.swift
@@ -1,14 +1,13 @@
 //
-//  DailyQuestTests.swift
+//  QuestUseCaseTests.swift
 //  DailyQuestTests
 //
-//  Created by jinwoong Kim on 2022/11/11.
+//  Created by jinwoong Kim on 2022/11/21.
 //
 
 import XCTest
-@testable import DailyQuest
 
-final class DailyQuestTests: XCTestCase {
+final class QuestUseCaseTests: XCTestCase {
 
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.

--- a/DailyQuest/DailyQuestTests/Mocks/Quest+Stub.swift
+++ b/DailyQuest/DailyQuestTests/Mocks/Quest+Stub.swift
@@ -6,3 +6,17 @@
 //
 
 import Foundation
+
+extension Quest {
+    static func stub(groupId: UUID,
+                     uuid: UUID,
+                     title: String,
+                     currentCount: Int,
+                     totalCount: Int) -> Self {
+        return .init(groupId: groupId,
+                     uuid: uuid,
+                     title: title,
+                     currentCount: currentCount,
+                     totalCount: totalCount)
+    }
+}

--- a/DailyQuest/DailyQuestTests/Mocks/Quest+Stub.swift
+++ b/DailyQuest/DailyQuestTests/Mocks/Quest+Stub.swift
@@ -1,0 +1,8 @@
+//
+//  Quest+Stub.swift
+//  DailyQuestTests
+//
+//  Created by jinwoong Kim on 2022/11/21.
+//
+
+import Foundation


### PR DESCRIPTION
### 📕 Issue Number

Close #28 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] QuestUseCase 프로토콜 작성
- [x] DefaultQuestUseCase 구현
- [x] Quest를 fetch해오는 액션 추가
- [x] Quest fetch 테스트
- [ ] Quest Add 액션
- [ ] Quest Add 테스트


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- QuestUseCase의 테스트 코드를 추가하여 진행하였습니다. 테스트는 Repository Mock 을 만들고, fetch 메서드가 정상적으로 Quest의 배열을 보내는 상황을 테스트 하였습니다. 정상적인 경우라면, Quest UseCase의 fetch 메서드를 실행하면, Quest의 배열을 방출하는 Observable을 반환할 것입니다.

```swift
func testQuestUseCase_WhenRepoSendCorrectQuests_ThenExpectationWillBeFulfilledWithSuccess() {
    // given
    questRepo = QuestRepositoryMock()
    
    questUseCase = DefaultQuestUseCase(questsRepository: questRepo)
    
    let expectation = XCTestExpectation(description: "test success")
    
    // when
    questUseCase
        .fetch(by: Date())
    // then
        .subscribe(onNext: { data in
            expectation.fulfill()
        }, onError: { _ in
            XCTFail("test failed")
        })
        .disposed(by: disposeBag)
    
    wait(for: [expectation], timeout: 1)
}
```
<img width="890" alt="Screenshot 2022-11-21 at 4 47 56 PM" src="https://user-images.githubusercontent.com/26710036/202993628-03094e88-7325-44ff-814f-9b776065cc7a.png">

- Quest를 추가하는 로직은 추가하지 않았습니다. Quest를 추가하는 뷰가 아직 없어서 구현 이후에 확장시키면 될 것 같아요.
- 기존에 가짜데이터로 처리되던 View와 ViewModel은 비활성화 하였습니다. Repo구현이 완료되면 연동 후, DB에 실제 데이터를 넣고 동작을 확인하면 될 것 같아요.

<br/><br/>
