### PR TITLE
Feature/enroll notify

### DIFF
--- a/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
+++ b/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		34283103292E2D9B00AE811B /* ToggleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34283102292E2D9B00AE811B /* ToggleCell.swift */; };
 		34283105292E2E3F00AE811B /* ToggleField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34283104292E2E3F00AE811B /* ToggleField.swift */; };
 		3429084F29383D73001812B1 /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3429084E29383D73001812B1 /* UserRepository.swift */; };
+		3436FCFA293F2654003575C3 /* Notification+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3436FCF9293F2654003575C3 /* Notification+.swift */; };
 		3449AD5B2922164B00B87619 /* Quest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3449AD5A2922164B00B87619 /* Quest.swift */; };
 		3449AD5D2922197000B87619 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3449AD5C2922197000B87619 /* User.swift */; };
 		3449AD6029222B3900B87619 /* UserInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3449AD5F29222B3900B87619 /* UserInfoCell.swift */; };
@@ -105,9 +106,9 @@
 		34EE0C662935FD7D002BEC23 /* BrowseItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3499552629235D1E007AB99E /* BrowseItemViewModel.swift */; };
 		34EE6EB72924C674005AF583 /* QuestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EE6EB62924C674005AF583 /* QuestView.swift */; };
 		34EE6EB92924CAA1005AF583 /* QuestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EE6EB82924CAA1005AF583 /* QuestViewModel.swift */; };
+		34FCD366293DE62700E0DC8A /* DefaultEnrollUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FCD365293DE62700E0DC8A /* DefaultEnrollUseCase.swift */; };
 		34FCD369293DEED600E0DC8A /* FriendViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FCD368293DEED600E0DC8A /* FriendViewController.swift */; };
 		34FCD36B293DF2F600E0DC8A /* FriendStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FCD36A293DF2F600E0DC8A /* FriendStatusView.swift */; };
-		34FCD366293DE62700E0DC8A /* DefaultEnrollUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FCD365293DE62700E0DC8A /* DefaultEnrollUseCase.swift */; };
 		34FEFB992935EA6D00954A40 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 34FEFB982935EA6D00954A40 /* Kingfisher */; };
 		34FF6C5A292B86F8002AFD4D /* SnapKit-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 34FF6C46292B8014002AFD4D /* SnapKit-Dynamic */; };
 		34FF6C5D292B8B27002AFD4D /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 34FF6C5C292B8B27002AFD4D /* RxCocoa */; };
@@ -253,6 +254,7 @@
 		34283102292E2D9B00AE811B /* ToggleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleCell.swift; sourceTree = "<group>"; };
 		34283104292E2E3F00AE811B /* ToggleField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleField.swift; sourceTree = "<group>"; };
 		3429084E29383D73001812B1 /* UserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
+		3436FCF9293F2654003575C3 /* Notification+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+.swift"; sourceTree = "<group>"; };
 		3449AD5A2922164B00B87619 /* Quest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quest.swift; sourceTree = "<group>"; };
 		3449AD5C2922197000B87619 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		3449AD5F29222B3900B87619 /* UserInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoCell.swift; sourceTree = "<group>"; };
@@ -307,9 +309,9 @@
 		34EE0C632935FD6B002BEC23 /* BrowseViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseViewModelTests.swift; sourceTree = "<group>"; };
 		34EE6EB62924C674005AF583 /* QuestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestView.swift; sourceTree = "<group>"; };
 		34EE6EB82924CAA1005AF583 /* QuestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestViewModel.swift; sourceTree = "<group>"; };
+		34FCD365293DE62700E0DC8A /* DefaultEnrollUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultEnrollUseCase.swift; sourceTree = "<group>"; };
 		34FCD368293DEED600E0DC8A /* FriendViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendViewController.swift; sourceTree = "<group>"; };
 		34FCD36A293DF2F600E0DC8A /* FriendStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendStatusView.swift; sourceTree = "<group>"; };
-		34FCD365293DE62700E0DC8A /* DefaultEnrollUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultEnrollUseCase.swift; sourceTree = "<group>"; };
 		9B1CFB3E292B585700CCE97A /* QuestDTO+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QuestDTO+Mapping.swift"; sourceTree = "<group>"; };
 		9BD8CCF22935BC0D00E6EA2F /* DefaultBrowseRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowseRepository.swift; sourceTree = "<group>"; };
 		9BD8CCF42935C38300E6EA2F /* UserDTO+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDTO+Mapping.swift"; sourceTree = "<group>"; };
@@ -619,6 +621,7 @@
 				34874AA129250C43000570DF /* UIButton+.swift */,
 				A5656458292BBDD40033E763 /* String+.swift */,
 				A50F9A3829266FD8005C00FE /* Date+.swift */,
+				3436FCF9293F2654003575C3 /* Notification+.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1314,6 +1317,7 @@
 				345687F42937329E00CA51E3 /* EnrollViewController.swift in Sources */,
 				A511229029384FAF00384B4B /* DefaultUserRepository.swift in Sources */,
 				342830FF292E2B2A00AE811B /* NavigateCell.swift in Sources */,
+				3436FCFA293F2654003575C3 /* Notification+.swift in Sources */,
 				A51F01D8292343A80031ECA2 /* RealmBrowseQuestsStorage.swift in Sources */,
 				A51F01DD2923468F0031ECA2 /* BrowseQuestEntity+Mapping.swift in Sources */,
 				345687F62937430200CA51E3 /* PlanDatePickerView.swift in Sources */,

--- a/DailyQuest/DailyQuest/Domain/UseCases/Home/DefaultEnrollUseCase.swift
+++ b/DailyQuest/DailyQuest/Domain/UseCases/Home/DefaultEnrollUseCase.swift
@@ -25,6 +25,15 @@ extension DefaultEnrollUseCase: EnrollUseCase {
                 true
             }
             .catchAndReturn(false)
+            .do(onSuccess: { _ in
+                let today = quests
+                    .filter { quest in
+                        Calendar.current.isDateInToday(quest.date)
+                    }
+                if !today.isEmpty {
+                    NotificationCenter.default.post(name: .updated, object: Date())
+                }
+            })
             .asObservable()
     }
 }

--- a/DailyQuest/DailyQuest/Presentation/Home/Flow/HomeCoordinator.swift
+++ b/DailyQuest/DailyQuest/Presentation/Home/Flow/HomeCoordinator.swift
@@ -50,17 +50,5 @@ final class DefaultHomeCoordinator: HomeCoordinator {
     func showAddQuestFlow() {
         let enrollViewController = homeSceneDIContainer.makeEnrollViewController()
         navigationController.present(enrollViewController, animated: true)
-        
-        enrollViewController
-            .coordinatorPublisher
-            .bind(onNext: { event in
-                switch event {
-                    case .success:
-                        enrollViewController.dismiss(animated: true)
-                    case .fail:
-                        break
-                }
-            })
-            .disposed(by: disposableBag)
     }
 }

--- a/DailyQuest/DailyQuest/Presentation/Home/Flow/HomeCoordinator.swift
+++ b/DailyQuest/DailyQuest/Presentation/Home/Flow/HomeCoordinator.swift
@@ -12,7 +12,6 @@ import RxSwift
 protocol HomeCoordinator: Coordinator {
     func showProfileFlow()
     func showAddQuestFlow()
-    func showAddFriendsFlow()
 }
 
 final class DefaultHomeCoordinator: HomeCoordinator {
@@ -51,9 +50,17 @@ final class DefaultHomeCoordinator: HomeCoordinator {
     func showAddQuestFlow() {
         let enrollViewController = homeSceneDIContainer.makeEnrollViewController()
         navigationController.present(enrollViewController, animated: true)
-    }
-    
-    func showAddFriendsFlow() {
         
+        enrollViewController
+            .coordinatorPublisher
+            .bind(onNext: { event in
+                switch event {
+                    case .success:
+                        enrollViewController.dismiss(animated: true)
+                    case .fail:
+                        break
+                }
+            })
+            .disposed(by: disposableBag)
     }
 }

--- a/DailyQuest/DailyQuest/Presentation/Home/ViewController/EnrollViewController.swift
+++ b/DailyQuest/DailyQuest/Presentation/Home/ViewController/EnrollViewController.swift
@@ -12,8 +12,6 @@ import RxCocoa
 import SnapKit
 
 final class EnrollViewController: UIViewController {
-    private(set) var coordinatorPublisher = PublishSubject<Event>()
-    
     private var viewModel: EnrollViewModel!
     private var disposableBag = DisposeBag()
     
@@ -129,7 +127,7 @@ final class EnrollViewController: UIViewController {
         
         bindToSubmitButton(output: output)
         bindToDayNamePickerView(output: output)
-        bindToCoordinatorPublisher(output: output)
+        bindToDismiss(output: output)
     }
     
     private func bindToSubmitButton(output: EnrollViewModel.Output) {
@@ -153,17 +151,14 @@ final class EnrollViewController: UIViewController {
             .disposed(by: disposableBag)
     }
     
-    private func bindToCoordinatorPublisher(output: EnrollViewModel.Output) {
+    private func bindToDismiss(output: EnrollViewModel.Output) {
         output
             .enrollResult
-            .map { result in
+            .bind(onNext: { [weak self] result in
                 if result {
-                    return Event.success
-                } else {
-                    return Event.fail
+                    self?.dismiss(animated: true)
                 }
-            }
-            .bind(to: coordinatorPublisher)
+            })
             .disposed(by: disposableBag)
     }
 }

--- a/DailyQuest/DailyQuest/Presentation/Home/ViewController/EnrollViewController.swift
+++ b/DailyQuest/DailyQuest/Presentation/Home/ViewController/EnrollViewController.swift
@@ -12,6 +12,8 @@ import RxCocoa
 import SnapKit
 
 final class EnrollViewController: UIViewController {
+    private(set) var coordinatorPublisher = PublishSubject<Event>()
+    
     private var viewModel: EnrollViewModel!
     private var disposableBag = DisposeBag()
     
@@ -125,21 +127,19 @@ final class EnrollViewController: UIViewController {
             )
         )
         
-        bindSubmitButton(output: output)
-        bindDayNamePickerView(output: output)
-        
-        output.enrollResult.subscribe(onNext: { print($0) })
-            .disposed(by: disposableBag)
+        bindToSubmitButton(output: output)
+        bindToDayNamePickerView(output: output)
+        bindToCoordinatorPublisher(output: output)
     }
     
-    private func bindSubmitButton(output: EnrollViewModel.Output) {
+    private func bindToSubmitButton(output: EnrollViewModel.Output) {
         output
             .buttonEnabled
             .drive(submitButton.rx.isEnabled)
             .disposed(by: disposableBag)
     }
     
-    private func bindDayNamePickerView(output: EnrollViewModel.Output) {
+    private func bindToDayNamePickerView(output: EnrollViewModel.Output) {
         output
             .dayButtonStatus
             .bind(onNext: { [weak self] index, isSelected in
@@ -151,6 +151,27 @@ final class EnrollViewController: UIViewController {
                 }
             })
             .disposed(by: disposableBag)
+    }
+    
+    private func bindToCoordinatorPublisher(output: EnrollViewModel.Output) {
+        output
+            .enrollResult
+            .map { result in
+                if result {
+                    return Event.success
+                } else {
+                    return Event.fail
+                }
+            }
+            .bind(to: coordinatorPublisher)
+            .disposed(by: disposableBag)
+    }
+}
+
+extension EnrollViewController {
+    enum Event {
+        case success
+        case fail
     }
 }
 

--- a/DailyQuest/DailyQuest/Presentation/Home/ViewController/EnrollViewController.swift
+++ b/DailyQuest/DailyQuest/Presentation/Home/ViewController/EnrollViewController.swift
@@ -154,10 +154,9 @@ final class EnrollViewController: UIViewController {
     private func bindToDismiss(output: EnrollViewModel.Output) {
         output
             .enrollResult
-            .bind(onNext: { [weak self] result in
-                if result {
-                    self?.dismiss(animated: true)
-                }
+            .filter({ $0 })
+            .bind(onNext: { [weak self] _ in
+                self?.dismiss(animated: true)
             })
             .disposed(by: disposableBag)
     }

--- a/DailyQuest/DailyQuest/Presentation/Home/ViewModel/EnrollViewModel.swift
+++ b/DailyQuest/DailyQuest/Presentation/Home/ViewModel/EnrollViewModel.swift
@@ -68,7 +68,7 @@ final class EnrollViewModel {
             )
             .map(createQuests(title:dates:quantity:))
             .flatMap(enrollUseCase.save(with:))
-            
+        
         return Output(buttonEnabled: buttonEnabled,
                       enrollResult: enrollResult,
                       dayButtonStatus: dayButtonStatus)

--- a/DailyQuest/DailyQuest/Presentation/Home/ViewModel/QuestViewModel.swift
+++ b/DailyQuest/DailyQuest/Presentation/Home/ViewModel/QuestViewModel.swift
@@ -36,8 +36,14 @@ final class QuestViewModel {
             .map { _ in Date() }
             .asObservable()
         
+        let notification = NotificationCenter
+            .default
+            .rx
+            .notification(.updated)
+            .compactMap({ $0.object as? Date })
+            
         let data = Observable
-            .merge(updated, input.viewDidLoad)
+            .merge(updated, input.viewDidLoad, notification)
             .flatMap(questUseCase.fetch(by:))
             .asDriver(onErrorJustReturn: [])
             

--- a/DailyQuest/DailyQuest/Utils/Notification+.swift
+++ b/DailyQuest/DailyQuest/Utils/Notification+.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+extension Notification.Name {
+    static let updated = Notification.Name("updated")
+}

--- a/DailyQuest/DailyQuest/Utils/Notification+.swift
+++ b/DailyQuest/DailyQuest/Utils/Notification+.swift
@@ -1,0 +1,8 @@
+//
+//  Notification+.swift
+//  DailyQuest
+//
+//  Created by jinwoong Kim on 2022/12/06.
+//
+
+import Foundation


### PR DESCRIPTION
### 📕 Issue Number

Close #89 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 완료버튼을 누르면 창이 dismiss
- [x] 추가된 퀘스트가 현재 날짜와 같다면, notification을 통해 notification emit

<img src="https://user-images.githubusercontent.com/26710036/205850811-a4e153d0-6304-4bc5-823e-c7c2f6419a7c.gif" width=350 />

<img width="1792" alt="Screenshot 2022-12-06 at 4 37 27 PM" src="https://user-images.githubusercontent.com/26710036/205850966-815194d7-22ed-4e5c-b3bd-6df0c9485fb1.png">




### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 처음 구상대로 Notification Center를 사용했습니다. refactor주간에 DIContainer 작업을 통해서 처리하는 걸로 해보려는데... 잘될지는 모르겠네요.

```swift
extension DefaultEnrollUseCase: EnrollUseCase {
    func save(with quests: [Quest]) -> Observable<Bool> {
        return questsRepository
            .save(with: quests)
            .map { _ in
                true
            }
            .catchAndReturn(false)
            .do(onSuccess: { _ in
                let today = quests
                    .filter { quest in
                        Calendar.current.isDateInToday(quest.date)
                    }
                if !today.isEmpty {
                    NotificationCenter.default.post(name: .updated, object: Date())
                }
            })
            .asObservable()
    }
}
```

- UseCase에서 퀘스트를 등록하고, 결과에 따라서, 그리고 등록된 퀘스트들 중에 오늘에 해당하는 퀘스드가 있다면, 이벤트를 보내게 했습니다.

<br/><br/>
