### PR TITLE
Feature/sign in sign up action

### DIFF
--- a/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
+++ b/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		3449AD5D2922197000B87619 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3449AD5C2922197000B87619 /* User.swift */; };
 		3449AD6029222B3900B87619 /* UserInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3449AD5F29222B3900B87619 /* UserInfoCell.swift */; };
 		344A459A293DC495007A3D37 /* EnrollUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344A4599293DC495007A3D37 /* EnrollUseCase.swift */; };
+		34517FCC2940A92100AB77E9 /* Alertable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34517FCB2940A92100AB77E9 /* Alertable.swift */; };
 		345687F42937329E00CA51E3 /* EnrollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345687F32937329E00CA51E3 /* EnrollViewController.swift */; };
 		345687F62937430200CA51E3 /* PlanDatePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345687F52937430200CA51E3 /* PlanDatePickerView.swift */; };
 		345687F829374D2500CA51E3 /* DayNamePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345687F729374D2500CA51E3 /* DayNamePickerView.swift */; };
@@ -273,6 +274,7 @@
 		3449AD5C2922197000B87619 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		3449AD5F29222B3900B87619 /* UserInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoCell.swift; sourceTree = "<group>"; };
 		344A4599293DC495007A3D37 /* EnrollUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrollUseCase.swift; sourceTree = "<group>"; };
+		34517FCB2940A92100AB77E9 /* Alertable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alertable.swift; sourceTree = "<group>"; };
 		345687F32937329E00CA51E3 /* EnrollViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnrollViewController.swift; sourceTree = "<group>"; };
 		345687F52937430200CA51E3 /* PlanDatePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanDatePickerView.swift; sourceTree = "<group>"; };
 		345687F729374D2500CA51E3 /* DayNamePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayNamePickerView.swift; sourceTree = "<group>"; };
@@ -657,6 +659,7 @@
 				A50F9A3829266FD8005C00FE /* Date+.swift */,
 				9BED4DE9293FA92900C60631 /* UIImageView+.swift */,
 				3436FCF9293F2654003575C3 /* Notification+.swift */,
+				34517FCB2940A92100AB77E9 /* Alertable.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1335,6 +1338,7 @@
 				347D258B292C60F40038FCA2 /* StatusView.swift in Sources */,
 				9BED4DE8293FA01400C60631 /* ProfileViewModel.swift in Sources */,
 				34642AB62925D9E40052FA0E /* UserInfoView.swift in Sources */,
+				34517FCC2940A92100AB77E9 /* Alertable.swift in Sources */,
 				349955292923600A007AB99E /* BrowseViewController.swift in Sources */,
 				34113BE82934917500AB4919 /* LoginViewModel.swift in Sources */,
 				34EE6EB72924C674005AF583 /* QuestView.swift in Sources */,

--- a/DailyQuest/DailyQuest/Infrastructure/FirebaseService/FirebaseService.swift
+++ b/DailyQuest/DailyQuest/Infrastructure/FirebaseService/FirebaseService.swift
@@ -81,6 +81,7 @@ extension FirebaseService {
                     if let error = error { throw error }
                     guard let authResult = authResult else { throw NetworkServiceError.noAuthError }
                     try self.createUser(uuid: authResult.user.uid, userDto: userDto)
+                    self.uid.accept(self.auth.currentUser?.uid)
                     single(.success(true))
                 } catch let error {
                     single(.failure(error))

--- a/DailyQuest/DailyQuest/Presentation/Settings/Flow/SettingsCoordinator.swift
+++ b/DailyQuest/DailyQuest/Presentation/Settings/Flow/SettingsCoordinator.swift
@@ -44,21 +44,33 @@ final class DefaultSettingsCoordinator: SettingsCoordinator {
     
     func showLoginFlow() {
         let loginViewController = settingsSceneDIContainer.makeLoginViewController()
+        navigationController.pushViewController(loginViewController, animated: true)
+        
         loginViewController
             .itemDidClick
             .bind(onNext: { [weak self] event in
                 switch event {
                     case .showSignUpFlow:
                         self?.showSignUpFlow()
+                    case .back:
+                        self?.navigationController.popViewController(animated: true)
                 }
             })
             .disposed(by: disposableBag)
-        
-        navigationController.pushViewController(loginViewController, animated: true)
     }
     
     func showSignUpFlow() {
         let signUpViewController = settingsSceneDIContainer.makeSignUpViewController()
         navigationController.pushViewController(signUpViewController, animated: true)
+        
+        signUpViewController
+            .itemDidClick
+            .bind(onNext: { [weak self] event in
+                switch event {
+                    case .back:
+                        self?.navigationController.popToRootViewController(animated: true)
+                }
+            })
+            .disposed(by: disposableBag)
     }
 }

--- a/DailyQuest/DailyQuest/Presentation/Settings/ViewController/LoginViewController.swift
+++ b/DailyQuest/DailyQuest/Presentation/Settings/ViewController/LoginViewController.swift
@@ -14,35 +14,36 @@ import SnapKit
 final class LoginViewController: UIViewController {
     enum Event {
         case showSignUpFlow
+        case back
     }
-
+    
     private var viewModel: LoginViewModel!
     private var disposableBag = DisposeBag()
-
+    
     var itemDidClick = PublishSubject<Event>()
-
+    
     private lazy var container: UIStackView = {
         let container = UIStackView()
         container.axis = .vertical
         container.spacing = 10
-
+        
         return container
     }()
-
+    
     private lazy var emailField: TextFieldForm = {
         let emailField = TextFieldForm()
         emailField.placeholder = "email"
         emailField.autocapitalizationType = .none
         return emailField
     }()
-
+    
     private lazy var passwordField: TextFieldForm = {
         let passwordField = TextFieldForm()
         passwordField.placeholder = "password"
         passwordField.isSecureTextEntry = true
         return passwordField
     }()
-
+    
     private lazy var submitButton: UIButton = {
         var config = UIButton.Configuration.filled()
         config.baseBackgroundColor = .maxYellow
@@ -50,7 +51,7 @@ final class LoginViewController: UIViewController {
         emailField.autocapitalizationType = .none
         return UIButton(configuration: config)
     }()
-
+    
     private lazy var signUpButton: UIButton = {
         var config = UIButton.Configuration.plain()
         config.baseForegroundColor = .gray
@@ -58,39 +59,39 @@ final class LoginViewController: UIViewController {
         config.buttonSize = .small
         return UIButton(configuration: config)
     }()
-
+    
     // MARK: Life Cycle
     static func create(with viewModel: LoginViewModel) -> LoginViewController {
         let vc = LoginViewController()
         vc.setup(with: viewModel)
-
+        
         return vc
     }
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         configureUI()
-
+        
         bind()
     }
-
+    
     private func configureUI() {
         view.backgroundColor = .white
-
+        
         container.addArrangedSubview(emailField)
         container.addArrangedSubview(passwordField)
         container.addArrangedSubview(submitButton)
         container.addArrangedSubview(signUpButton)
-
+        
         view.addSubview(container)
-
+        
         container.snp.makeConstraints { make in
             make.center.equalToSuperview()
             make.width.equalToSuperview().multipliedBy(0.8)
         }
     }
-
+    
     private func setup(with authViewModel: LoginViewModel) {
         viewModel = authViewModel
     }
@@ -102,25 +103,33 @@ extension LoginViewController {
             guard let self = self else { return }
             self.itemDidClick.onNext(.showSignUpFlow)
         }).disposed(by: disposableBag)
-
+        
         let input = LoginViewModel.Input(
             emailFieldDidEditEvent: emailField.rx.text.orEmpty.asObservable(),
             passwordFieldDidEditEvent: passwordField.rx.text.orEmpty.asObservable(),
             submitButtonDidTapEvent: submitButton.rx.tap.asObservable()
         )
-
+        
         let output = viewModel.transform(input: input, disposeBag: disposableBag)
-
+        
         output
             .buttonEnabled
             .drive(submitButton.rx.isEnabled)
             .disposed(by: disposableBag)
-
+        
         output
             .loginResult
-            .subscribe(onNext: { result in
-            print("login result is :::: ", result)
-        })
+            .bind(onNext: analyse(result:))
             .disposed(by: disposableBag)
+    }
+}
+
+extension LoginViewController: Alertable {
+    private func analyse(result: Bool) {
+        if result {
+            itemDidClick.onNext(.back)
+        } else {
+            showAlert(title: "로그인 실패", message: "이메일과 비밀번호를 확인해주세요.")
+        }
     }
 }

--- a/DailyQuest/DailyQuest/Presentation/Settings/ViewController/SignUpViewController.swift
+++ b/DailyQuest/DailyQuest/Presentation/Settings/ViewController/SignUpViewController.swift
@@ -12,25 +12,31 @@ import RxCocoa
 import SnapKit
 
 final class SignUpViewController: UIViewController {
+    enum Event {
+        case back
+    }
+    
     private var viewModel: SignUpViewModel!
     private var disposableBag = DisposeBag()
-
+    
+    var itemDidClick = PublishSubject<Event>()
+    
     private lazy var container: UIStackView = {
         let container = UIStackView()
         container.axis = .vertical
         container.spacing = 10
-
+        
         return container
     }()
-
+    
     private lazy var emailField: TextFieldForm = {
         let emailField = TextFieldForm()
         emailField.placeholder = "email"
         emailField.autocapitalizationType = .none
-
+        
         return emailField
     }()
-
+    
     private lazy var passwordField: TextFieldForm = {
         let passwordField = TextFieldForm()
         passwordField.placeholder = "password (6글자 이상)"
@@ -38,63 +44,63 @@ final class SignUpViewController: UIViewController {
         
         return passwordField
     }()
-
+    
     private lazy var passwordConfirmField: TextFieldForm = {
         let passwordConfirmField = TextFieldForm()
         passwordConfirmField.placeholder = "password 확인"
         passwordConfirmField.isSecureTextEntry = true
         return passwordConfirmField
     }()
-
+    
     private lazy var nickNameField: TextFieldForm = {
         let nickNameField = TextFieldForm()
         nickNameField.placeholder = "닉네임"
         emailField.autocapitalizationType = .none
         return nickNameField
     }()
-
+    
     private lazy var submitButton: UIButton = {
         var config = UIButton.Configuration.filled()
         config.baseBackgroundColor = .maxYellow
         config.title = "회원가입"
-
+        
         return UIButton(configuration: config)
     }()
-
+    
     // MARK: Life Cycle
     static func create(with viewModel: SignUpViewModel) -> SignUpViewController {
         let vc = SignUpViewController()
         vc.setup(with: viewModel)
         return vc
     }
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         configureUI()
-
+        
         bind()
     }
-
+    
     private func configureUI() {
         view.backgroundColor = .white
-
+        
         [emailField,
-            passwordField,
-            passwordConfirmField,
-            nickNameField,
-            submitButton].forEach { field in
+         passwordField,
+         passwordConfirmField,
+         nickNameField,
+         submitButton].forEach { field in
             container.addArrangedSubview(field)
         }
-
+        
         view.addSubview(container)
-
+        
         container.snp.makeConstraints { make in
             make.center.equalToSuperview()
             make.width.equalToSuperview().multipliedBy(0.8)
         }
     }
-
+    
     private func setup(with authViewModel: SignUpViewModel) {
         viewModel = authViewModel
     }
@@ -109,19 +115,27 @@ extension SignUpViewController {
             nickNameFieldDidEditEvent: nickNameField.rx.text.orEmpty.asObservable(),
             submitButtonDidTapEvent: submitButton.rx.tap.asObservable()
         )
-
+        
         let output = viewModel.transform(input: input, disposeBag: disposableBag)
-
+        
         output
             .buttonEnabled
             .drive(submitButton.rx.isEnabled)
             .disposed(by: disposableBag)
-
+        
         output
             .signUpResult
-            .subscribe(onNext: { result in
-            print("SignUp result is :::: ", result)
-        })
+            .bind(onNext: analyse(result:))
             .disposed(by: disposableBag)
+    }
+}
+
+extension SignUpViewController: Alertable {
+    private func analyse(result: Bool) {
+        if result {
+            itemDidClick.onNext(.back)
+        } else {
+            showAlert(title: "회원가입 실패", message: "중복되는 아이디입니다.")
+        }
     }
 }

--- a/DailyQuest/DailyQuest/Utils/Alertable.swift
+++ b/DailyQuest/DailyQuest/Utils/Alertable.swift
@@ -1,0 +1,28 @@
+//
+//  Alertable.swift
+//  DailyQuest
+//
+//  Created by jinwoong Kim on 2022/12/07.
+//
+
+import UIKit
+
+protocol Alertable {}
+
+extension Alertable where Self: UIViewController {
+    func showAlert(title: String,
+                   message: String,
+                   preferredStyle: UIAlertController.Style = .alert,
+                           completion: (() -> Void)? = nil)
+    {
+        let title = title
+        let message = message
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        
+        let okAction = UIAlertAction(title: "Ok", style: .default)
+        
+        alert.addAction(okAction)
+        
+        self.present(alert, animated: true, completion: completion)
+    }
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #104 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 로그인 성공시, 화면을 Pop
- [x] 회원가입 성공시, 화면을 popToRoot
- [x] 로그인과 회원가입 실패시, alert창 띄워줌

<img src="https://user-images.githubusercontent.com/26710036/206165280-d02425cf-b2a7-447d-bff1-4cc188056dde.gif" width=350 />

- 중복되는 이메일로 인해 회원가입 실패

<img src="https://user-images.githubusercontent.com/26710036/206165502-4ea745fc-44b6-4931-9c42-5f879304150f.gif" width=350 />

- 문제없으면 회원가입 성공, 처음 뷰로 돌아감

<img src="https://user-images.githubusercontent.com/26710036/206165575-3fc21653-d9ff-477e-919b-272d33c7cf1c.gif" width=350 />

- 로그인 실패시, alert를, 성공하면 view를 pop

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

```swift
    func signUp(email: String, password: String, userDto: UserDTO) -> Single<Bool> {
       ...
            self.auth.createUser(withEmail: email, password: password) { authResult, error in
                do {
                    if let error = error { throw error }
                    guard let authResult = authResult else { throw NetworkServiceError.noAuthError }
                    try self.createUser(uuid: authResult.user.uid, userDto: userDto)

                   /** 이부분 추가! */
                    self.uid.accept(self.auth.currentUser?.uid)

                    single(.success(true))
                } catch let error {
                    single(.failure(error))
                }
        ....
    }
```

- 파이어베이스는 회원가입 성공하면, 바로 로그인 처리됩니다!! 이로 인해서, Data의 FirebaseService의 회원가입 로직에 다음부분을 추가했습니다.

<br/><br/>
