### PR TITLE
Refactor/quest view

### DIFF
--- a/DailyQuest/DailyQuest/Domain/UseCases/Home/DefaultEnrollUseCase.swift
+++ b/DailyQuest/DailyQuest/Domain/UseCases/Home/DefaultEnrollUseCase.swift
@@ -26,13 +26,8 @@ extension DefaultEnrollUseCase: EnrollUseCase {
             }
             .catchAndReturn(false)
             .do(onSuccess: { _ in
-                let today = quests
-                    .filter { quest in
-                        Calendar.current.isDateInToday(quest.date)
-                    }
-                if !today.isEmpty {
-                    NotificationCenter.default.post(name: .updated, object: Date())
-                }
+                let dates = quests.map { $0.date }
+                NotificationCenter.default.post(name: .updated, object: dates)
             })
             .asObservable()
     }


### PR DESCRIPTION
### 📕 Issue Number

Close #112 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 퀘스트 추가시, questview에 보여지는 로직 변경


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 퀘스트를 등록하는 상황을 제외하고, QuestView가 usecase를 통하여 퀘스트를 가져와서 보여주는 경우는 다음 세가지 경우 입니다.
    1. view가 처음 load 되었을 때
    2. questcell을 클릭하여, 업데이트 하였을 때
    3. calendarcell을 클릭하여, 해당 날짜로 이동하였을 때
- 퀘스트를 등록하는 상황에서도 QuestView를 업데이트하여 보여주어야 합니다. 이 때의 로직은 다음과 같습니다.
    1. 지금 현재위치의 날짜(캘린더 셀을 선택했을 때의 날짜나, 처음 앱을 켰을 경우는 오늘)를 기억합니다.
    2. 등록되는 퀘스트들 중에서, NotificationCenter를 통해 오는 날짜들 중 현재위치날짜를 포함하는 날짜가 있는지 확인합니다.
    3. 있다면 해당 날짜를 이벤트로하여 view를 업데이트하는 output과 연결합니다.

```swift
final class HomeViewModel {
    private let questUseCase: QuestUseCase
    private var calendarUseCase: CalendarUseCase
    private var currentDate = Date()
....
```
1번에 해당하는 부분입니다. `currentDate`를 HomeViewModel이 가지고 있습니다. 

```swift
        let notification = NotificationCenter
            .default
            .rx
            .notification(.updated)
            .compactMap({ $0.object as? [Date] })
            .withUnretained(self)
            .compactMap { owner, dates in
                let result = dates.filter { date in
                    Calendar.current.isDate(owner.currentDate, inSameDayAs: date)
                }
                
                return !result.isEmpty ? owner.currentDate : nil
            }
```
2번에 해당하는 부분입니다. 상기했듯, NotificationCenter로 부터 오는 Notification은 등록되는 퀘스트들의 날짜들을 전송합니다. 이를 비교해서 존재한다면, `notification`이 이벤트를 방출할 수 있게 합니다. 그렇지 않다면, `nil`을 방출해서 `compactMap`에 걸러져, 이벤트 방출로 이어지지 못하게 합니다.

```swift
        let data = Observable
            .merge(updated, input.viewDidLoad, input.daySelected, notification)
            .do(onNext: { [weak self] date in self?.currentDate = date })
            .flatMap(questUseCase.fetch(by:))
            .asDriver(onErrorJustReturn: [])
```
3번에 해당하는 부분입니다. `merge`로 묶인 publisher(혹은 observable)들은 모두 현재위치날짜에 해당하는 Date를 방출합니다. 2번에서 notification이 현재위치날짜를 방출하거나 아니면 아예 방출하지 않는다는 것을 유념하세요.
`do()` 오퍼레이터를 통해서 사이드이펙트를 처리할 수 있습니다. calendar cell 클릭이벤트(`input.daySelected`)가 발생하면 여기를 통해서 viewModel이 쥐고있는 `currentDate`를 변경합니다. 


<br/><br/>
