### PR TITLE
Refactor/di container

### DIFF
--- a/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
+++ b/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
@@ -31,8 +31,6 @@
 		3416FC93292B59D300B504C5 /* QuestRepositoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3416FC92292B59D300B504C5 /* QuestRepositoryMock.swift */; };
 		3416FC95292B5AD600B504C5 /* QuestUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3416FC94292B5AD600B504C5 /* QuestUseCaseTests.swift */; };
 		3416FC96292B5B5400B504C5 /* Quest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3449AD5A2922164B00B87619 /* Quest.swift */; };
-		3417598229470D0600C9123F /* DailyContainer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3417598129470CFF00C9123F /* DailyContainer.framework */; };
-		3417598329470D0600C9123F /* DailyContainer.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3417598129470CFF00C9123F /* DailyContainer.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		341759932947426000C9123F /* StroageKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341759922947426000C9123F /* StroageKey.swift */; };
 		34175995294743E300C9123F /* RepositoryKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34175994294743E300C9123F /* RepositoryKey.swift */; };
 		34175998294745DB00C9123F /* ServiceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34175997294745DB00C9123F /* ServiceKey.swift */; };
@@ -223,7 +221,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		3417598029470CFF00C9123F /* PBXContainerItemProxy */ = {
+		3417599F2947567900C9123F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 3417597C29470CFF00C9123F /* DailyContainer.xcodeproj */;
 			proxyType = 2;
@@ -253,7 +251,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				3417598329470D0600C9123F /* DailyContainer.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -284,7 +281,7 @@
 		3416FC8D292B593C00B504C5 /* Quest+Stub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Quest+Stub.swift"; sourceTree = "<group>"; };
 		3416FC92292B59D300B504C5 /* QuestRepositoryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestRepositoryMock.swift; sourceTree = "<group>"; };
 		3416FC94292B5AD600B504C5 /* QuestUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestUseCaseTests.swift; sourceTree = "<group>"; };
-		3417597C29470CFF00C9123F /* DailyContainer.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DailyContainer.xcodeproj; path = ../../../../../../swift/DailyContainer/DailyContainer.xcodeproj; sourceTree = "<group>"; };
+		3417597C29470CFF00C9123F /* DailyContainer.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DailyContainer.xcodeproj; path = DailyContainer/DailyContainer.xcodeproj; sourceTree = "<group>"; };
 		341759922947426000C9123F /* StroageKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StroageKey.swift; sourceTree = "<group>"; };
 		34175994294743E300C9123F /* RepositoryKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryKey.swift; sourceTree = "<group>"; };
 		34175997294745DB00C9123F /* ServiceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceKey.swift; sourceTree = "<group>"; };
@@ -432,7 +429,6 @@
 			files = (
 				A50DE90B292B73B900E1FD60 /* FirebaseDatabaseSwift in Frameworks */,
 				3409154B292DE5CC007873A8 /* FirebaseAuth in Frameworks */,
-				3417598229470D0600C9123F /* DailyContainer.framework in Frameworks */,
 				34091551292DE5CC007873A8 /* FirebaseStorage in Frameworks */,
 				A5AC96DF292239CA003B7637 /* RealmSwift in Frameworks */,
 				34FF6C5D292B8B27002AFD4D /* RxCocoa in Frameworks */,
@@ -575,14 +571,6 @@
 			path = SubFrameworks;
 			sourceTree = "<group>";
 		};
-		3417597D29470CFF00C9123F /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				3417598129470CFF00C9123F /* DailyContainer.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		3417598529470D8800C9123F /* Container */ = {
 			isa = PBXGroup;
 			children = (
@@ -624,6 +612,14 @@
 				3417599A2947479100C9123F /* UseCaseKey.swift */,
 			);
 			path = UseCase;
+			sourceTree = "<group>";
+		};
+		3417599C2947567900C9123F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				341759A02947567900C9123F /* DailyContainer.framework */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 		3417B13F2935DA1500900454 /* Browse */ = {
@@ -1393,7 +1389,7 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 3417597D29470CFF00C9123F /* Products */;
+					ProductGroup = 3417599C2947567900C9123F /* Products */;
 					ProjectRef = 3417597C29470CFF00C9123F /* DailyContainer.xcodeproj */;
 				},
 			);
@@ -1407,11 +1403,11 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		3417598129470CFF00C9123F /* DailyContainer.framework */ = {
+		341759A02947567900C9123F /* DailyContainer.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = DailyContainer.framework;
-			remoteRef = 3417598029470CFF00C9123F /* PBXContainerItemProxy */;
+			remoteRef = 3417599F2947567900C9123F /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
+++ b/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
@@ -31,6 +31,12 @@
 		3416FC93292B59D300B504C5 /* QuestRepositoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3416FC92292B59D300B504C5 /* QuestRepositoryMock.swift */; };
 		3416FC95292B5AD600B504C5 /* QuestUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3416FC94292B5AD600B504C5 /* QuestUseCaseTests.swift */; };
 		3416FC96292B5B5400B504C5 /* Quest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3449AD5A2922164B00B87619 /* Quest.swift */; };
+		3417598229470D0600C9123F /* DailyContainer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3417598129470CFF00C9123F /* DailyContainer.framework */; };
+		3417598329470D0600C9123F /* DailyContainer.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3417598129470CFF00C9123F /* DailyContainer.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		341759932947426000C9123F /* StroageKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341759922947426000C9123F /* StroageKey.swift */; };
+		34175995294743E300C9123F /* RepositoryKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34175994294743E300C9123F /* RepositoryKey.swift */; };
+		34175998294745DB00C9123F /* ServiceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34175997294745DB00C9123F /* ServiceKey.swift */; };
+		3417599B2947479100C9123F /* UseCaseKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417599A2947479100C9123F /* UseCaseKey.swift */; };
 		3417B1442935DA4A00900454 /* BrowseUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417B1432935DA4A00900454 /* BrowseUseCase.swift */; };
 		3417B1462935DA9D00900454 /* DefaultBrowseUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3417B1452935DA9D00900454 /* DefaultBrowseUseCase.swift */; };
 		341932E3294185A0003DE808 /* StatusView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341932E2294185A0003DE808 /* StatusView+.swift */; };
@@ -217,6 +223,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		3417598029470CFF00C9123F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3417597C29470CFF00C9123F /* DailyContainer.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 34D68A8429470C1E005DD41F;
+			remoteInfo = DailyContainer;
+		};
 		34ACC340291DE9C100741371 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 34ACC321291DE9C000741371 /* Project object */;
@@ -234,6 +247,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		3417598429470D0600C9123F /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				3417598329470D0600C9123F /* DailyContainer.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		34FF6C2E292B8014002AFD4D /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -260,6 +284,11 @@
 		3416FC8D292B593C00B504C5 /* Quest+Stub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Quest+Stub.swift"; sourceTree = "<group>"; };
 		3416FC92292B59D300B504C5 /* QuestRepositoryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestRepositoryMock.swift; sourceTree = "<group>"; };
 		3416FC94292B5AD600B504C5 /* QuestUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestUseCaseTests.swift; sourceTree = "<group>"; };
+		3417597C29470CFF00C9123F /* DailyContainer.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DailyContainer.xcodeproj; path = ../../../../../../swift/DailyContainer/DailyContainer.xcodeproj; sourceTree = "<group>"; };
+		341759922947426000C9123F /* StroageKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StroageKey.swift; sourceTree = "<group>"; };
+		34175994294743E300C9123F /* RepositoryKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryKey.swift; sourceTree = "<group>"; };
+		34175997294745DB00C9123F /* ServiceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceKey.swift; sourceTree = "<group>"; };
+		3417599A2947479100C9123F /* UseCaseKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCaseKey.swift; sourceTree = "<group>"; };
 		3417B1432935DA4A00900454 /* BrowseUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseUseCase.swift; sourceTree = "<group>"; };
 		3417B1452935DA9D00900454 /* DefaultBrowseUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowseUseCase.swift; sourceTree = "<group>"; };
 		341932E2294185A0003DE808 /* StatusView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatusView+.swift"; sourceTree = "<group>"; };
@@ -403,6 +432,7 @@
 			files = (
 				A50DE90B292B73B900E1FD60 /* FirebaseDatabaseSwift in Frameworks */,
 				3409154B292DE5CC007873A8 /* FirebaseAuth in Frameworks */,
+				3417598229470D0600C9123F /* DailyContainer.framework in Frameworks */,
 				34091551292DE5CC007873A8 /* FirebaseStorage in Frameworks */,
 				A5AC96DF292239CA003B7637 /* RealmSwift in Frameworks */,
 				34FF6C5D292B8B27002AFD4D /* RxCocoa in Frameworks */,
@@ -535,6 +565,65 @@
 				34EE0C5A2935FA2E002BEC23 /* BrowseRepositoryMock.swift */,
 			);
 			path = Mocks;
+			sourceTree = "<group>";
+		};
+		3417597B29470CF000C9123F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3417597C29470CFF00C9123F /* DailyContainer.xcodeproj */,
+			);
+			path = Frameworks;
+			sourceTree = "<group>";
+		};
+		3417597D29470CFF00C9123F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3417598129470CFF00C9123F /* DailyContainer.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3417598529470D8800C9123F /* Container */ = {
+			isa = PBXGroup;
+			children = (
+				341759992947478300C9123F /* UseCase */,
+				34175996294745D300C9123F /* Service */,
+				341759892947126700C9123F /* Storage */,
+				3417598629470D9D00C9123F /* Repository */,
+			);
+			path = Container;
+			sourceTree = "<group>";
+		};
+		3417598629470D9D00C9123F /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				34175994294743E300C9123F /* RepositoryKey.swift */,
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
+		341759892947126700C9123F /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				341759922947426000C9123F /* StroageKey.swift */,
+			);
+			path = Storage;
+			sourceTree = "<group>";
+		};
+		34175996294745D300C9123F /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				34175997294745DB00C9123F /* ServiceKey.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
+		341759992947478300C9123F /* UseCase */ = {
+			isa = PBXGroup;
+			children = (
+				3417599A2947479100C9123F /* UseCaseKey.swift */,
+			);
+			path = UseCase;
 			sourceTree = "<group>";
 		};
 		3417B13F2935DA1500900454 /* Browse */ = {
@@ -873,6 +962,7 @@
 		34ACC320291DE9C000741371 = {
 			isa = PBXGroup;
 			children = (
+				3417597B29470CF000C9123F /* Frameworks */,
 				34ACC32B291DE9C000741371 /* DailyQuest */,
 				34ACC342291DE9C100741371 /* DailyQuestTests */,
 				34ACC34C291DE9C100741371 /* DailyQuestUITests */,
@@ -928,6 +1018,7 @@
 		34ACC367291DF00B00741371 /* Application */ = {
 			isa = PBXGroup;
 			children = (
+				3417598529470D8800C9123F /* Container */,
 				34A529CF29247875001BAD34 /* Protocols */,
 				3499551329232525007AB99E /* DIContainer */,
 				34ACC32C291DE9C000741371 /* AppDelegate.swift */,
@@ -1187,6 +1278,7 @@
 				34ACC325291DE9C000741371 /* Sources */,
 				34ACC326291DE9C000741371 /* Frameworks */,
 				34ACC327291DE9C000741371 /* Resources */,
+				3417598429470D0600C9123F /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1299,6 +1391,12 @@
 			);
 			productRefGroup = 34ACC32A291DE9C000741371 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 3417597D29470CFF00C9123F /* Products */;
+					ProjectRef = 3417597C29470CFF00C9123F /* DailyContainer.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				34ACC328291DE9C000741371 /* DailyQuest */,
@@ -1307,6 +1405,16 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		3417598129470CFF00C9123F /* DailyContainer.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = DailyContainer.framework;
+			remoteRef = 3417598029470CFF00C9123F /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		34ACC327291DE9C000741371 /* Resources */ = {
@@ -1349,6 +1457,7 @@
 				342830F6292E1ACA00AE811B /* PlainItemViewModel.swift in Sources */,
 				345687FE29378AB900CA51E3 /* EnrollViewModel.swift in Sources */,
 				34A529D129247880001BAD34 /* Coordinator.swift in Sources */,
+				3417599B2947479100C9123F /* UseCaseKey.swift in Sources */,
 				B5606665293DD9A000CEFEA8 /* CalendarUseCase.swift in Sources */,
 				34113BEB2934A3B200AB4919 /* LoginViewController.swift in Sources */,
 				340A724929348B1B00B26AA6 /* AuthUseCase.swift in Sources */,
@@ -1427,6 +1536,7 @@
 				34404D96293EF9E50007E661 /* DefaultSettingsUseCase.swift in Sources */,
 				3417B1442935DA4A00900454 /* BrowseUseCase.swift in Sources */,
 				A51189C329226E66008A9D33 /* QuestEntity+Mapping.swift in Sources */,
+				34175995294743E300C9123F /* RepositoryKey.swift in Sources */,
 				A51F01D3292340360031ECA2 /* BrowseQuestsStorage.swift in Sources */,
 				A50F9A3729266F6F005C00FE /* FirebaseService.swift in Sources */,
 				3472E8F52942135D00BB304F /* FriendQuestUseCase.swift in Sources */,
@@ -1437,6 +1547,7 @@
 				A51F01CA2923397E0031ECA2 /* UserInfoEntity.swift in Sources */,
 				345687F42937329E00CA51E3 /* EnrollViewController.swift in Sources */,
 				A5BD61E629423FBB0075970F /* SyncManager.swift in Sources */,
+				34175998294745DB00C9123F /* ServiceKey.swift in Sources */,
 				A511229029384FAF00384B4B /* DefaultUserRepository.swift in Sources */,
 				A5003ABB293F914500082A9C /* DefaultUserUseCase.swift in Sources */,
 				342830FF292E2B2A00AE811B /* NavigateCell.swift in Sources */,
@@ -1444,6 +1555,7 @@
 				A51F01D8292343A80031ECA2 /* RealmBrowseQuestsStorage.swift in Sources */,
 				A51F01DD2923468F0031ECA2 /* BrowseQuestEntity+Mapping.swift in Sources */,
 				345687F62937430200CA51E3 /* PlanDatePickerView.swift in Sources */,
+				341759932947426000C9123F /* StroageKey.swift in Sources */,
 				34FCD369293DEED600E0DC8A /* FriendViewController.swift in Sources */,
 				3416FC88292B54DB00B504C5 /* QuestUseCase.swift in Sources */,
 				9BD8CCF72935D7BB00E6EA2F /* BrowseQuestDTO+Mapping.swift in Sources */,

--- a/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
+++ b/DailyQuest/DailyQuest.xcodeproj/project.pbxproj
@@ -567,12 +567,12 @@
 			path = Mocks;
 			sourceTree = "<group>";
 		};
-		3417597B29470CF000C9123F /* Frameworks */ = {
+		3417597B29470CF000C9123F /* SubFrameworks */ = {
 			isa = PBXGroup;
 			children = (
 				3417597C29470CFF00C9123F /* DailyContainer.xcodeproj */,
 			);
-			path = Frameworks;
+			path = SubFrameworks;
 			sourceTree = "<group>";
 		};
 		3417597D29470CFF00C9123F /* Products */ = {
@@ -962,7 +962,7 @@
 		34ACC320291DE9C000741371 = {
 			isa = PBXGroup;
 			children = (
-				3417597B29470CF000C9123F /* Frameworks */,
+				3417597B29470CF000C9123F /* SubFrameworks */,
 				34ACC32B291DE9C000741371 /* DailyQuest */,
 				34ACC342291DE9C100741371 /* DailyQuestTests */,
 				34ACC34C291DE9C100741371 /* DailyQuestUITests */,

--- a/DailyQuest/DailyQuest/Application/Container/Repository/RepositoryKey.swift
+++ b/DailyQuest/DailyQuest/Application/Container/Repository/RepositoryKey.swift
@@ -1,0 +1,8 @@
+//
+//  RepositoryKey.swift
+//  DailyQuest
+//
+//  Created by jinwoong Kim on 2022/12/12.
+//
+
+import Foundation

--- a/DailyQuest/DailyQuest/Application/Container/Repository/RepositoryKey.swift
+++ b/DailyQuest/DailyQuest/Application/Container/Repository/RepositoryKey.swift
@@ -6,3 +6,24 @@
 //
 
 import Foundation
+import DailyContainer
+
+struct QuestRepositoryKey: InjectionKey {
+    typealias Value = QuestsRepository
+}
+
+struct AuthRepositoryKey: InjectionKey {
+    typealias Value = AuthRepository
+}
+
+struct BrowseRepositoryKey: InjectionKey {
+    typealias Value = BrowseRepository
+}
+
+struct UserRepositoryKey: InjectionKey {
+    typealias Value = UserRepository
+}
+
+struct ProtectedUserRepositoryKey: InjectionKey {
+    typealias Value = ProtectedUserRepository
+}

--- a/DailyQuest/DailyQuest/Application/Container/Service/ServiceKey.swift
+++ b/DailyQuest/DailyQuest/Application/Container/Service/ServiceKey.swift
@@ -6,3 +6,8 @@
 //
 
 import Foundation
+import DailyContainer
+
+struct ServiceKey: InjectionKey {
+    typealias Value = NetworkService
+}

--- a/DailyQuest/DailyQuest/Application/Container/Service/ServiceKey.swift
+++ b/DailyQuest/DailyQuest/Application/Container/Service/ServiceKey.swift
@@ -1,0 +1,8 @@
+//
+//  ServiceKey.swift
+//  DailyQuest
+//
+//  Created by jinwoong Kim on 2022/12/12.
+//
+
+import Foundation

--- a/DailyQuest/DailyQuest/Application/Container/Storage/StroageKey.swift
+++ b/DailyQuest/DailyQuest/Application/Container/Storage/StroageKey.swift
@@ -6,3 +6,16 @@
 //
 
 import Foundation
+import DailyContainer
+
+struct QuestStorageKey: InjectionKey {
+    typealias Value = QuestsStorage
+}
+
+struct BrowseQuestStorageKey: InjectionKey {
+    typealias Value = BrowseQuestsStorage
+}
+
+struct UserInfoStorageKey: InjectionKey {
+    typealias Value = UserInfoStorage
+}

--- a/DailyQuest/DailyQuest/Application/Container/Storage/StroageKey.swift
+++ b/DailyQuest/DailyQuest/Application/Container/Storage/StroageKey.swift
@@ -1,0 +1,8 @@
+//
+//  StroageKey.swift
+//  DailyQuest
+//
+//  Created by jinwoong Kim on 2022/12/12.
+//
+
+import Foundation

--- a/DailyQuest/DailyQuest/Application/Container/UseCase/UseCaseKey.swift
+++ b/DailyQuest/DailyQuest/Application/Container/UseCase/UseCaseKey.swift
@@ -1,0 +1,8 @@
+//
+//  UseCaseKey.swift
+//  DailyQuest
+//
+//  Created by jinwoong Kim on 2022/12/12.
+//
+
+import Foundation

--- a/DailyQuest/DailyQuest/Application/Container/UseCase/UseCaseKey.swift
+++ b/DailyQuest/DailyQuest/Application/Container/UseCase/UseCaseKey.swift
@@ -6,3 +6,25 @@
 //
 
 import Foundation
+import DailyContainer
+
+// MARK: - Home Scene
+struct QuestUseCaseKey: InjectionKey {
+    typealias Value = QuestUseCase
+}
+
+struct EnrollUseCaseKey: InjectionKey {
+    typealias Value = EnrollUseCase
+}
+
+struct UserUseCaseKey: InjectionKey {
+    typealias Value = UserUseCase
+}
+
+struct CalendarUseCaseKey: InjectionKey {
+    typealias Value = CalendarUseCase
+}
+
+// MARK: - Browse Scene
+
+// MARK: - Settings Scene

--- a/DailyQuest/DailyQuest/Application/DIContainer/AppDIContainer.swift
+++ b/DailyQuest/DailyQuest/Application/DIContainer/AppDIContainer.swift
@@ -11,9 +11,9 @@ import DailyContainer
 final class AppDIContainer {
     
     init() {
-        registService()
-        registStorage()
-        registRepository()
+        registerService()
+        registerStorage()
+        registerRepository()
     }
     
     func makeHomeSceneDIContainer() -> HomeSceneDIContainer {
@@ -30,22 +30,22 @@ final class AppDIContainer {
 }
 
 private extension AppDIContainer {
-    func registService() {
-        Container.shared.regist {
+    func registerService() {
+        Container.shared.register {
             Module(ServiceKey.self) { FirebaseService.shared }
         }
     }
     
-    func registStorage() {
-        Container.shared.regist {
+    func registerStorage() {
+        Container.shared.register {
             Module(QuestStorageKey.self) { RealmQuestsStorage() }
             Module(BrowseQuestStorageKey.self) { RealmBrowseQuestsStorage() }
             Module(UserInfoStorageKey.self) { RealmUserInfoStorage() }
         }
     }
     
-    func registRepository() {
-        Container.shared.regist {
+    func registerRepository() {
+        Container.shared.register {
             Module(QuestRepositoryKey.self) {
                 @Injected(QuestStorageKey.self)
                 var questStorage: QuestsStorage

--- a/DailyQuest/DailyQuest/Application/DIContainer/AppDIContainer.swift
+++ b/DailyQuest/DailyQuest/Application/DIContainer/AppDIContainer.swift
@@ -6,8 +6,15 @@
 //
 
 import Foundation
+import DailyContainer
 
 final class AppDIContainer {
+    
+    init() {
+        registService()
+        registStorage()
+        registRepository()
+    }
     
     func makeHomeSceneDIContainer() -> HomeSceneDIContainer {
         return HomeSceneDIContainer()
@@ -20,4 +27,68 @@ final class AppDIContainer {
     func makeSettingsSceneDIContainer() -> SettingsSceneDIContainer {
         return SettingsSceneDIContainer()
     }
+}
+
+private extension AppDIContainer {
+    func registService() {
+        Container.shared.regist {
+            Module(ServiceKey.self) { FirebaseService.shared }
+        }
+    }
+    
+    func registStorage() {
+        Container.shared.regist {
+            Module(QuestStorageKey.self) { RealmQuestsStorage() }
+            Module(BrowseQuestStorageKey.self) { RealmBrowseQuestsStorage() }
+            Module(UserInfoStorageKey.self) { RealmUserInfoStorage() }
+        }
+    }
+    
+    func registRepository() {
+        Container.shared.regist {
+            Module(QuestRepositoryKey.self) {
+                @Injected(QuestStorageKey.self)
+                var questStorage: QuestsStorage
+                return DefaultQuestsRepository(persistentStorage: questStorage)
+            }
+            
+            Module(AuthRepositoryKey.self) {
+                @Injected(QuestStorageKey.self)
+                var questStorage: QuestsStorage
+                
+                @Injected(UserInfoStorageKey.self)
+                var userInfoStorage: UserInfoStorage
+                
+                return DefaultAuthRepository(persistentQuestsStorage: questStorage,
+                                             persistentUserStorage: userInfoStorage)
+            }
+            
+            Module(BrowseRepositoryKey.self) {
+                @Injected(BrowseQuestStorageKey.self)
+                var browseQuestStroage: BrowseQuestsStorage
+                
+                @Injected(ServiceKey.self)
+                var networkService: NetworkService
+                
+                return DefaultBrowseRepository(persistentStorage: browseQuestStroage,
+                                               networkService: networkService)
+            }
+            
+            /**
+             Networ service instance needed.
+             */
+            Module(UserRepositoryKey.self) {
+                @Injected(UserInfoStorageKey.self)
+                var userInfoStorage: UserInfoStorage
+                
+                return DefaultUserRepository(persistentStorage: userInfoStorage)
+            }
+            
+            /**
+             Protected User Repository Injection
+             goes here.
+             */
+        }
+    }
+
 }

--- a/DailyQuest/DailyQuest/Application/DIContainer/HomeSceneDIContainer.swift
+++ b/DailyQuest/DailyQuest/Application/DIContainer/HomeSceneDIContainer.swift
@@ -6,52 +6,74 @@
 //
 
 import UIKit
+import DailyContainer
 
 final class HomeSceneDIContainer {
 
-    lazy var questsStorage: QuestsStorage = RealmQuestsStorage()
-    lazy var userStorage: UserInfoStorage = RealmUserInfoStorage()
-    lazy var networkService: NetworkService = FirebaseService.shared
-
-    // MARK: - Repositories
-    func makeQuestsRepository() -> QuestsRepository {
-        return DefaultQuestsRepository(persistentStorage: questsStorage)
+    init() {
+        registUseCase()
     }
-
-    func makeUserRepository() -> UserRepository {
-        return DefaultUserRepository(persistentStorage: userStorage, networkService: networkService)
-    }
-
-    // MARK: - Use Cases
-    func makeQuestUseCase() -> QuestUseCase {
-        return DefaultQuestUseCase(questsRepository: makeQuestsRepository())
-    }
-
-    func makeEnrollUseCase() -> EnrollUseCase {
-        return DefaultEnrollUseCase(questsRepository: makeQuestsRepository())
-    }
-
-    func makeCalendarUseCase() -> CalendarUseCase {
-        return HomeCalendarUseCase(questsRepository: makeQuestsRepository())
-    }
-
-    func makeUesrUseCase() -> UserUseCase {
-        return DefaultUserUseCase(userRepository: makeUserRepository())
+    
+    func registUseCase() {
+        Container.shared.regist {
+            Module(QuestUseCaseKey.self) {
+                @Injected(QuestRepositoryKey.self)
+                var questRepository: QuestsRepository
+                
+                return DefaultQuestUseCase(questsRepository: questRepository)
+            }
+            
+            Module(EnrollUseCaseKey.self) {
+                @Injected(QuestRepositoryKey.self)
+                var questRepository: QuestsRepository
+                
+                return DefaultEnrollUseCase(questsRepository: questRepository)
+            }
+            
+            Module(UserUseCaseKey.self) {
+                @Injected(UserRepositoryKey.self)
+                var userRepository: UserRepository
+                
+                return DefaultUserUseCase(userRepository: userRepository)
+            }
+            
+            Module(CalendarUseCaseKey.self) {
+                @Injected(QuestRepositoryKey.self)
+                var questRepository: QuestsRepository
+                
+                return HomeCalendarUseCase(questsRepository: questRepository)
+            }
+        }
     }
 
     // MARK: - View Models
     func makeHomeViewModel() -> HomeViewModel {
-        return HomeViewModel(userUseCase: makeUesrUseCase(),
-                             questUseCase: makeQuestUseCase(),
-                             calendarUseCase: makeCalendarUseCase())
+        @Injected(QuestUseCaseKey.self)
+        var questUseCase: QuestUseCase
+        
+        @Injected(UserUseCaseKey.self)
+        var userUseCase: UserUseCase
+        
+        @Injected(CalendarUseCaseKey.self)
+        var calendarUseCase: CalendarUseCase
+        
+        return HomeViewModel(userUseCase: userUseCase,
+                             questUseCase: questUseCase,
+                             calendarUseCase: calendarUseCase)
     }
 
     func makeEnrollViewModel() -> EnrollViewModel {
-        return EnrollViewModel(enrollUseCase: makeEnrollUseCase())
+        @Injected(EnrollUseCaseKey.self)
+        var enrollUseCase: EnrollUseCase
+        
+        return EnrollViewModel(enrollUseCase: enrollUseCase)
     }
 
     func makeProfileViewModel() -> ProfileViewModel {
-        return ProfileViewModel(userUseCase: makeUesrUseCase())
+        @Injected(UserUseCaseKey.self)
+        var userUseCase: UserUseCase
+        
+        return ProfileViewModel(userUseCase: userUseCase)
     }
 
     // MARK: - View Controller

--- a/DailyQuest/DailyQuest/Application/DIContainer/HomeSceneDIContainer.swift
+++ b/DailyQuest/DailyQuest/Application/DIContainer/HomeSceneDIContainer.swift
@@ -13,38 +13,6 @@ final class HomeSceneDIContainer {
     init() {
         registerUseCase()
     }
-    
-    func registerUseCase() {
-        Container.shared.register {
-            Module(QuestUseCaseKey.self) {
-                @Injected(QuestRepositoryKey.self)
-                var questRepository: QuestsRepository
-                
-                return DefaultQuestUseCase(questsRepository: questRepository)
-            }
-            
-            Module(EnrollUseCaseKey.self) {
-                @Injected(QuestRepositoryKey.self)
-                var questRepository: QuestsRepository
-                
-                return DefaultEnrollUseCase(questsRepository: questRepository)
-            }
-            
-            Module(UserUseCaseKey.self) {
-                @Injected(UserRepositoryKey.self)
-                var userRepository: UserRepository
-                
-                return DefaultUserUseCase(userRepository: userRepository)
-            }
-            
-            Module(CalendarUseCaseKey.self) {
-                @Injected(QuestRepositoryKey.self)
-                var questRepository: QuestsRepository
-                
-                return HomeCalendarUseCase(questsRepository: questRepository)
-            }
-        }
-    }
 
     // MARK: - View Models
     func makeHomeViewModel() -> HomeViewModel {
@@ -94,5 +62,39 @@ final class HomeSceneDIContainer {
                              homeSceneDIContainer: HomeSceneDIContainer) -> HomeCoordinator {
         return DefaultHomeCoordinator(navigationController: navigationController,
                                       homeSceneDIContainer: homeSceneDIContainer)
+    }
+}
+
+private extension HomeSceneDIContainer {
+    func registerUseCase() {
+        Container.shared.register {
+            Module(QuestUseCaseKey.self) {
+                @Injected(QuestRepositoryKey.self)
+                var questRepository: QuestsRepository
+                
+                return DefaultQuestUseCase(questsRepository: questRepository)
+            }
+            
+            Module(EnrollUseCaseKey.self) {
+                @Injected(QuestRepositoryKey.self)
+                var questRepository: QuestsRepository
+                
+                return DefaultEnrollUseCase(questsRepository: questRepository)
+            }
+            
+            Module(UserUseCaseKey.self) {
+                @Injected(UserRepositoryKey.self)
+                var userRepository: UserRepository
+                
+                return DefaultUserUseCase(userRepository: userRepository)
+            }
+            
+            Module(CalendarUseCaseKey.self) {
+                @Injected(QuestRepositoryKey.self)
+                var questRepository: QuestsRepository
+                
+                return HomeCalendarUseCase(questsRepository: questRepository)
+            }
+        }
     }
 }

--- a/DailyQuest/DailyQuest/Application/DIContainer/HomeSceneDIContainer.swift
+++ b/DailyQuest/DailyQuest/Application/DIContainer/HomeSceneDIContainer.swift
@@ -11,11 +11,11 @@ import DailyContainer
 final class HomeSceneDIContainer {
 
     init() {
-        registUseCase()
+        registerUseCase()
     }
     
-    func registUseCase() {
-        Container.shared.regist {
+    func registerUseCase() {
+        Container.shared.register {
             Module(QuestUseCaseKey.self) {
                 @Injected(QuestRepositoryKey.self)
                 var questRepository: QuestsRepository

--- a/DailyQuest/SubFrameworks/DailyContainer/DailyContainer.xcodeproj/project.pbxproj
+++ b/DailyQuest/SubFrameworks/DailyContainer/DailyContainer.xcodeproj/project.pbxproj
@@ -1,0 +1,354 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		34D68A8929470C1E005DD41F /* DailyContainer.docc in Sources */ = {isa = PBXBuildFile; fileRef = 34D68A8829470C1E005DD41F /* DailyContainer.docc */; };
+		34D68A8A29470C1E005DD41F /* DailyContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 34D68A8729470C1E005DD41F /* DailyContainer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34D68A9329470C2C005DD41F /* Container.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D68A9029470C2B005DD41F /* Container.swift */; };
+		34D68A9429470C2C005DD41F /* InjectionKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D68A9129470C2B005DD41F /* InjectionKey.swift */; };
+		34D68A9529470C2C005DD41F /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D68A9229470C2B005DD41F /* Injected.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		34D68A8429470C1E005DD41F /* DailyContainer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DailyContainer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		34D68A8729470C1E005DD41F /* DailyContainer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DailyContainer.h; sourceTree = "<group>"; };
+		34D68A8829470C1E005DD41F /* DailyContainer.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = DailyContainer.docc; sourceTree = "<group>"; };
+		34D68A9029470C2B005DD41F /* Container.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Container.swift; sourceTree = "<group>"; };
+		34D68A9129470C2B005DD41F /* InjectionKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InjectionKey.swift; sourceTree = "<group>"; };
+		34D68A9229470C2B005DD41F /* Injected.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Injected.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		34D68A8129470C1E005DD41F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		34D68A7A29470C1E005DD41F = {
+			isa = PBXGroup;
+			children = (
+				34D68A8629470C1E005DD41F /* DailyContainer */,
+				34D68A8529470C1E005DD41F /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		34D68A8529470C1E005DD41F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				34D68A8429470C1E005DD41F /* DailyContainer.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		34D68A8629470C1E005DD41F /* DailyContainer */ = {
+			isa = PBXGroup;
+			children = (
+				34D68A9029470C2B005DD41F /* Container.swift */,
+				34D68A9229470C2B005DD41F /* Injected.swift */,
+				34D68A9129470C2B005DD41F /* InjectionKey.swift */,
+				34D68A8729470C1E005DD41F /* DailyContainer.h */,
+				34D68A8829470C1E005DD41F /* DailyContainer.docc */,
+			);
+			path = DailyContainer;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		34D68A7F29470C1E005DD41F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				34D68A8A29470C1E005DD41F /* DailyContainer.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		34D68A8329470C1E005DD41F /* DailyContainer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 34D68A8D29470C1E005DD41F /* Build configuration list for PBXNativeTarget "DailyContainer" */;
+			buildPhases = (
+				34D68A7F29470C1E005DD41F /* Headers */,
+				34D68A8029470C1E005DD41F /* Sources */,
+				34D68A8129470C1E005DD41F /* Frameworks */,
+				34D68A8229470C1E005DD41F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DailyContainer;
+			productName = DailyContainer;
+			productReference = 34D68A8429470C1E005DD41F /* DailyContainer.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		34D68A7B29470C1E005DD41F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1410;
+				TargetAttributes = {
+					34D68A8329470C1E005DD41F = {
+						CreatedOnToolsVersion = 14.1;
+					};
+				};
+			};
+			buildConfigurationList = 34D68A7E29470C1E005DD41F /* Build configuration list for PBXProject "DailyContainer" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 34D68A7A29470C1E005DD41F;
+			productRefGroup = 34D68A8529470C1E005DD41F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				34D68A8329470C1E005DD41F /* DailyContainer */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		34D68A8229470C1E005DD41F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		34D68A8029470C1E005DD41F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				34D68A8929470C1E005DD41F /* DailyContainer.docc in Sources */,
+				34D68A9329470C2C005DD41F /* Container.swift in Sources */,
+				34D68A9429470C2C005DD41F /* InjectionKey.swift in Sources */,
+				34D68A9529470C2C005DD41F /* Injected.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		34D68A8B29470C1E005DD41F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		34D68A8C29470C1E005DD41F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		34D68A8E29470C1E005DD41F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.DailyContainer;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		34D68A8F29470C1E005DD41F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.DailyContainer;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		34D68A7E29470C1E005DD41F /* Build configuration list for PBXProject "DailyContainer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				34D68A8B29470C1E005DD41F /* Debug */,
+				34D68A8C29470C1E005DD41F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		34D68A8D29470C1E005DD41F /* Build configuration list for PBXNativeTarget "DailyContainer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				34D68A8E29470C1E005DD41F /* Debug */,
+				34D68A8F29470C1E005DD41F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 34D68A7B29470C1E005DD41F /* Project object */;
+}

--- a/DailyQuest/SubFrameworks/DailyContainer/DailyContainer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/DailyQuest/SubFrameworks/DailyContainer/DailyContainer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/DailyQuest/SubFrameworks/DailyContainer/DailyContainer.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/DailyQuest/SubFrameworks/DailyContainer/DailyContainer.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/DailyQuest/SubFrameworks/DailyContainer/DailyContainer/Container.swift
+++ b/DailyQuest/SubFrameworks/DailyContainer/DailyContainer/Container.swift
@@ -1,0 +1,55 @@
+//
+//  Container.swift
+//  DailyContainer
+//
+//  Created by jinwoong Kim on 2022/12/12.
+//
+
+import Foundation
+
+public class Container {
+    public static var shared = Container()
+    
+    private var modules: [String: Module] = [:]
+    
+    public init() {}
+    deinit { modules.removeAll() }
+}
+
+extension Container {
+    func register(with module: Module) {
+        modules[module.name] = module
+    }
+    
+    func resolve<T>(for type: Any.Type?) -> T {
+        let name = type.map { String(describing: $0) } ?? String(describing: T.self)
+        
+        guard let dependancy: T = modules[name]?.resolve() as? T else {
+            fatalError("dependancy \(T.self) not resolved.")
+        }
+        
+        return dependancy
+    }
+}
+
+public extension Container {
+    func register(@ModuleBuilder _ modules: () -> [Module]) {
+        modules().forEach { register(with: $0) }
+    }
+    
+    func register(@ModuleBuilder _ module: () -> Module) {
+        register(with: module())
+    }
+    
+    @resultBuilder
+    struct ModuleBuilder {
+        public static func buildBlock(_ modules: Module...) -> [Module] {
+            modules
+        }
+        
+        public static func buildBlock(_ module: Module) -> Module {
+            module
+        }
+    }
+}
+

--- a/DailyQuest/SubFrameworks/DailyContainer/DailyContainer/DailyContainer.docc/DailyContainer.md
+++ b/DailyQuest/SubFrameworks/DailyContainer/DailyContainer/DailyContainer.docc/DailyContainer.md
@@ -1,0 +1,13 @@
+# ``DailyContainer``
+
+<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+
+## Overview
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+## Topics
+
+### <!--@START_MENU_TOKEN@-->Group<!--@END_MENU_TOKEN@-->
+
+- <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->

--- a/DailyQuest/SubFrameworks/DailyContainer/DailyContainer/DailyContainer.h
+++ b/DailyQuest/SubFrameworks/DailyContainer/DailyContainer/DailyContainer.h
@@ -1,0 +1,18 @@
+//
+//  DailyContainer.h
+//  DailyContainer
+//
+//  Created by jinwoong Kim on 2022/12/12.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for DailyContainer.
+FOUNDATION_EXPORT double DailyContainerVersionNumber;
+
+//! Project version string for DailyContainer.
+FOUNDATION_EXPORT const unsigned char DailyContainerVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <DailyContainer/PublicHeader.h>
+
+

--- a/DailyQuest/SubFrameworks/DailyContainer/DailyContainer/Injected.swift
+++ b/DailyQuest/SubFrameworks/DailyContainer/DailyContainer/Injected.swift
@@ -1,0 +1,26 @@
+//
+//  Injected.swift
+//  DailyContainer
+//
+//  Created by jinwoong Kim on 2022/12/12.
+//
+
+import Foundation
+
+@propertyWrapper
+public class Injected<Value> {
+    private let lazyValue: (() -> Value)
+    private var storage: Value?
+    
+    public var wrappedValue: Value {
+        storage ?? {
+            let value: Value = lazyValue()
+            storage = value
+            return value
+        }()
+    }
+    
+    public init<K>(_ key: K.Type) where K: InjectionKey, Value == K.Value {
+        lazyValue = { key.currentValue }
+    }
+}

--- a/DailyQuest/SubFrameworks/DailyContainer/DailyContainer/InjectionKey.swift
+++ b/DailyQuest/SubFrameworks/DailyContainer/DailyContainer/InjectionKey.swift
@@ -1,0 +1,29 @@
+//
+//  InjectionKey.swift
+//  DailyContainer
+//
+//  Created by jinwoong Kim on 2022/12/12.
+//
+
+import Foundation
+
+public protocol InjectionKey {
+    associatedtype Value
+    static var currentValue: Self.Value { get }
+}
+
+public extension InjectionKey {
+    static var currentValue: Value {
+        return Container.shared.resolve(for: Self.self)
+    }
+}
+
+public struct Module {
+    let name: String
+    let resolve: () -> Any
+    
+    public init<T: InjectionKey>(_ name: T.Type, _ resolve: @escaping () -> Any) {
+        self.name = String(describing: name)
+        self.resolve = resolve
+    }
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #143 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] Container 역할을 하는 프레임워크 생성
- [x] result builder를 사용하여 일괄적으로 dependancy를 register
- [x] property wrapper를 사용하여 dependancy를 resolve


### 📘 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- custom framework가 git에 푸시가 안되는 것 같아요. ignore에 포함된 것 같지는 않던데, 뭐가 문제일까요..?

- custom framework인 DailyContainer은 `Container.swift`, `Injected.swift`, 그리고 `InjectionKey.swift`로 구성되어 있습니다.
- `Container.swift`에서는 디펜던시를 등록하고, resolve하는 역할을 수행합니다.
- `Injected.swift`에서는 property wrapper와 관련된 역할을 수행합니다.
- `InjectionKey.swift`에서는 key를 기반으로 dependancy를 resolove할 수 있게 도와줍니다.

```swift
private extension HomeSceneDIContainer {
    func registerUseCase() {
        Container.shared.register {
            Module(QuestUseCaseKey.self) {
                @Injected(QuestRepositoryKey.self)
                var questRepository: QuestsRepository
                
                return DefaultQuestUseCase(questsRepository: questRepository)
            }
            
            Module(EnrollUseCaseKey.self) {
                @Injected(QuestRepositoryKey.self)
                var questRepository: QuestsRepository
                
                return DefaultEnrollUseCase(questsRepository: questRepository)
            }
            
            Module(UserUseCaseKey.self) {
                @Injected(UserRepositoryKey.self)
                var userRepository: UserRepository
                
                return DefaultUserUseCase(userRepository: userRepository)
            }
            
            Module(CalendarUseCaseKey.self) {
                @Injected(QuestRepositoryKey.self)
                var questRepository: QuestsRepository
                
                return HomeCalendarUseCase(questsRepository: questRepository)
            }
        }
    }
}

```
- 현재 HomeScene의 UseCase를 해당 프레임워크를 사용하여 처리한 모습입니다. viewModel은 이 코드에서 등록된 use case를 property wrapper로 resolve하여 사용하고, view controller은 기존과 동일합니다. 이부분도 수정할지 여러분들의 의견이 궁금하네요.

<br/><br/>
